### PR TITLE
fix: extend default search engine options to include 'exa' and 'brave' in config validation (#5)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ export const config: AppConfig = {
 };
 
 // Validate config
-if (!['bing', 'duckduckgo'].includes(config.defaultSearchEngine)) {
+if (!['bing', 'duckduckgo', 'exa', 'brave'].includes(config.defaultSearchEngine)) {
     console.warn(`Invalid DEFAULT_SEARCH_ENGINE: "${config.defaultSearchEngine}", falling back to "bing"`);
     config.defaultSearchEngine = 'bing';
 }


### PR DESCRIPTION
fix: extend default search engine options to include 'exa' and 'brave' in config validation (#5)