### PR TITLE
feat: Configurable tool names

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -166,6 +166,11 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 | `MODE` | `both`                  | `both`, `http`, `stdio` | 服务器模式：同时支持HTTP+STDIO、仅HTTP或仅STDIO    |
 | `PORT` | `3000`                  | 1-65535 | 服务器端口                                |
 | `ALLOWED_SEARCH_ENGINES` | 空（全部可用） | 逗号分隔的引擎名称 | 限制可使用的搜索引擎，如默认搜索引擎不在范围，则默认第一个为默认搜索引擎 |
+| `MCP_TOOL_SEARCH_NAME` | `search` | 有效的MCP工具名称 | 搜索工具的自定义名称 |
+| `MCP_TOOL_FETCH_LINUXDO_NAME` | `fetchLinuxDoArticle` | 有效的MCP工具名称 | Linux.do文章获取工具的自定义名称 |
+| `MCP_TOOL_FETCH_CSDN_NAME` | `fetchCsdnArticle` | 有效的MCP工具名称 | CSDN文章获取工具的自定义名称 |
+| `MCP_TOOL_FETCH_GITHUB_NAME` | `fetchGithubReadme` | 有效的MCP工具名称 | GitHub README获取工具的自定义名称 |
+| `MCP_TOOL_FETCH_JUEJIN_NAME` | `fetchJuejinArticle` | 有效的MCP工具名称 | 掘金文章获取工具的自定义名称 |
 
 **常用配置示例：**
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 | `MODE` | `both`                  | `both`, `http`, `stdio` | Server mode: both HTTP+STDIO, HTTP only, or STDIO only |
 | `PORT` | `3000`                  | 1-65535 | Server port |
 | `ALLOWED_SEARCH_ENGINES` | empty (all available) | Comma-separated engine names | Limit which search engines can be used; if the default engine is not in this list, the first allowed engine becomes the default |
+| `MCP_TOOL_SEARCH_NAME` | `search` | Valid MCP tool name | Custom name for the search tool |
+| `MCP_TOOL_FETCH_LINUXDO_NAME` | `fetchLinuxDoArticle` | Valid MCP tool name | Custom name for the Linux.do article fetch tool |
+| `MCP_TOOL_FETCH_CSDN_NAME` | `fetchCsdnArticle` | Valid MCP tool name | Custom name for the CSDN article fetch tool |
+| `MCP_TOOL_FETCH_GITHUB_NAME` | `fetchGithubReadme` | Valid MCP tool name | Custom name for the GitHub README fetch tool |
+| `MCP_TOOL_FETCH_JUEJIN_NAME` | `fetchJuejinArticle` | Valid MCP tool name | Custom name for the Juejin article fetch tool |
 
 **Common configurations:**
 ```bash

--- a/src/tools/setupTools.ts
+++ b/src/tools/setupTools.ts
@@ -128,7 +128,29 @@ const validateGithubUrl = (url: string): boolean => {
     }
 };
 
+// 获取工具名称，优先使用环境变量，否则使用默认值
+function getToolName(envVarName: string, defaultName: string): string {
+    const configuredName = process.env[envVarName];
+    if (configuredName) {
+        // Validate tool name to ensure it follows MCP naming conventions
+        if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(configuredName)) {
+            console.warn(`Invalid tool name "${configuredName}" from environment variable ${envVarName}. Using default: "${defaultName}"`);
+            return defaultName;
+        }
+        console.log(`Using custom tool name "${configuredName}" for ${envVarName}`);
+        return configuredName;
+    }
+    return defaultName;
+}
+
 export const setupTools = (server: McpServer): void => {
+    // Get configurable tool names from environment variables
+    const searchToolName = getToolName('MCP_TOOL_SEARCH_NAME', 'search');
+    const fetchLinuxDoToolName = getToolName('MCP_TOOL_FETCH_LINUXDO_NAME', 'fetchLinuxDoArticle');
+    const fetchCsdnToolName = getToolName('MCP_TOOL_FETCH_CSDN_NAME', 'fetchCsdnArticle');
+    const fetchGithubToolName = getToolName('MCP_TOOL_FETCH_GITHUB_NAME', 'fetchGithubReadme');
+    const fetchJuejinToolName = getToolName('MCP_TOOL_FETCH_JUEJIN_NAME', 'fetchJuejinArticle');
+
     // 搜索工具
     // 生成搜索工具的动态描述
     const getSearchDescription = () => {
@@ -158,7 +180,7 @@ export const setupTools = (server: McpServer): void => {
     };
 
     server.tool(
-        'search',
+        searchToolName,
         getSearchDescription(),
         {
             query: z.string().min(1, "Search query must not be empty"),
@@ -210,7 +232,7 @@ export const setupTools = (server: McpServer): void => {
 
     // 获取 Linux.do 文章工具
     server.tool(
-        'fetchLinuxDoArticle',
+        fetchLinuxDoToolName,
         "Fetch full article content from a linux.do post URL",
         {
             url: z.string().url().refine(
@@ -244,7 +266,7 @@ export const setupTools = (server: McpServer): void => {
 
     // 获取 CSDN 文章工具
     server.tool(
-        'fetchCsdnArticle',
+        fetchCsdnToolName,
         "Fetch full article content from a csdn post URL",
         {
             url: z.string().url().refine(
@@ -278,7 +300,7 @@ export const setupTools = (server: McpServer): void => {
 
     // 获取 GitHub README 工具
     server.tool(
-        'fetchGithubReadme',
+        fetchGithubToolName,
         "Fetch README content from a GitHub repository URL",
         {
             url: z.string().min(1).refine(
@@ -322,7 +344,7 @@ export const setupTools = (server: McpServer): void => {
 
     // 获取掘金文章工具
     server.tool(
-        'fetchJuejinArticle',
+        fetchJuejinToolName,
         "Fetch full article content from a Juejin(掘金) post URL",
         {
             url: z.string().url().refine(


### PR DESCRIPTION
This pull request implements configurable tool names, e.g. "search" can be renamed to "webSearch" or to any other valid MCP tool name, by setting environment variables.

This is particularly useful for Gemini CLI and Qwen Code users, as their APIs don't allow a tool to use the name "search".

Changes are fully backwards compatible. Tool names remain the same, unless the user explicitly redefines them. I have also implemented name validation, logging and falling back to defaults.

Provides a solution and basically resolves Aas-ee/open-webSearch#21.

Note: please check the changes to the Chinese version of the documentation, xièxiè.