### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 A Model Context Protocol (MCP) server based on multi-engine search results, supporting free web search without API keys.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aas-ee-open-websearch).
+
 ## Features
 
 - Web search using multi-engine results


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aas-ee-open-websearch)