### PR TITLE
docs(readme): add comprehensive skill usage documentation

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -136,6 +136,43 @@ MCP工具支持：
 - `skill`
   - 适合作为 agent 的引导层，帮助 agent 发现、启用并使用最小可行路径；skill 不替代 MCP、CLI 或本地 daemon，通常推荐与 CLI 和/或本地 daemon 搭配使用。
 
+## 配合 skill 使用
+
+先给 agent 安装 `open-websearch` skill：
+
+```bash
+npx skills add https://github.com/Aas-ee/open-webSearch --skill open-websearch
+```
+
+首次使用时，skill 通常会先检测当前环境里是否已经有可用的 `open-websearch` path；如果没有，则先引导安装、启用和验证，确认 capability active 之后，再通过最小可行路径执行搜索或抓取。
+
+如果当前环境里 agent 不能自动完成 setup 或 activation，你也可以明确让它先启动本地 daemon：
+
+```bash
+open-websearch serve
+open-websearch status
+```
+
+请把安装代理和运行时代理分开理解：
+
+- 安装阶段代理 / 镜像
+  - 用于 skill 或 agent 安装 `open-websearch`、`playwright` 等 npm 包时。
+  - 在受限网络里，npm 自己的代理参数或 npm config 往往比通用 shell 代理变量更稳，例如：
+
+```bash
+npm --proxy http://127.0.0.1:7890 --https-proxy http://127.0.0.1:7890 install -g open-websearch
+```
+
+- 运行时代理
+  - 用于 daemon 已安装并准备执行联网 `search` / `fetch` 时。
+  - 这影响的是 `open-websearch serve` 启动后的联网请求，例如：
+
+```bash
+USE_PROXY=true PROXY_URL=http://127.0.0.1:7890 open-websearch serve
+```
+
+如果安装阶段需要 npm 代理，而 daemon 启动后联网 search/fetch 也需要代理，那么这两步要分别处理，不要混成同一种代理设置。
+
 ## CLI 与本地 daemon
 
 CLI 用于一次性执行。本地 daemon 是常驻的本地 HTTP 服务，适合重复调用并减少冷启动摩擦。请用 `open-websearch serve` 显式启动 daemon，用 `open-websearch status` 显式检查状态。

--- a/README.md
+++ b/README.md
@@ -48,6 +48,43 @@
 - `Skill`
   - Best as an agent-facing guidance layer for setup and usage. A skill does not replace MCP, CLI, or the local daemon; it typically works together with the CLI and/or local daemon to help an agent discover, activate, and use the smallest working path.
 
+## Use with a Skill
+
+Install the `open-websearch` skill for your agent first:
+
+```bash
+npx skills add https://github.com/Aas-ee/open-webSearch --skill open-websearch
+```
+
+On first use, the skill typically follows this path: detect whether a usable `open-websearch` path already exists, guide setup/enablement if it does not, validate that the capability is active, and only then continue with search or fetch through the smallest working path.
+
+If the current environment cannot complete setup or activation automatically, you can explicitly have the agent start the local daemon first:
+
+```bash
+open-websearch serve
+open-websearch status
+```
+
+Keep installation proxy settings separate from runtime proxy settings:
+
+- Installation proxy / mirror
+  - Use this when the skill or agent is installing `open-websearch`, `playwright`, or other npm packages.
+  - In restricted networks, npm-specific flags or npm config often work better than generic shell proxy variables, for example:
+
+```bash
+npm --proxy http://127.0.0.1:7890 --https-proxy http://127.0.0.1:7890 install -g open-websearch
+```
+
+- Runtime proxy
+  - Use this when the daemon is already installed and is about to perform live `search` / `fetch` work.
+  - This affects the `open-websearch` network traffic after `serve` starts, for example:
+
+```bash
+USE_PROXY=true PROXY_URL=http://127.0.0.1:7890 open-websearch serve
+```
+
+If the agent can only get through the package-install step with npm proxy settings, but live search/fetch also needs a proxy after startup, those are two separate configuration steps and should be handled separately.
+
 ## CLI and Local Daemon
 
 CLI is for one-shot execution. The local daemon is a long-lived local HTTP service for repeated calls with lower startup friction. Use `open-websearch serve` as the explicit daemon start command and `open-websearch status` as the explicit daemon status command.


### PR DESCRIPTION
- Document skill installation process with npx commands
- Add detailed workflow for first-time skill usage and setup
- Include instructions for manual daemon startup when needed
- Separate installation proxy settings from runtime proxy settings
- Provide specific npm proxy configuration examples for restricted networks
- Document runtime proxy configuration for search and fetch operations
- Add Chinese translation in README-zh.md with equivalent details
- Clarify the distinction between package install and live search proxy needs