### PR TITLE
feat: add Tavily as a parallel search engine option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.2",
         "@mozilla/readability": "^0.6.0",
+        "@tavily/core": "^0.7.2",
         "@types/cheerio": "^0.22.35",
         "axios": "^1.7.9",
         "cheerio": "^1.0.0",
@@ -520,6 +521,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tavily/core": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@tavily/core/-/core-0.7.2.tgz",
+      "integrity": "sha512-N9xfw9miPD1jyVKYTMWV1hQvWPNjATT9Hffr6tv7VMHzwOPOeBwfX/R25ZE2F7meTyq6xSeGxclWnLVH2xHqFA==",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "https-proxy-agent": "^7.0.6",
+        "js-tiktoken": "^1.0.14"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -740,6 +751,25 @@
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -1702,6 +1732,14 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/jsdom": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "test:article-fetch:live": "tsc && node build/test/test-article-fetch-live.js"
   },
   "dependencies": {
-    "@mozilla/readability": "^0.6.0",
     "@modelcontextprotocol/sdk": "^1.11.2",
+    "@mozilla/readability": "^0.6.0",
+    "@tavily/core": "^0.7.2",
     "@types/cheerio": "^0.22.35",
     "axios": "^1.7.9",
     "cheerio": "^1.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 // src/config.ts
 export interface AppConfig {
     // Search engine configuration
-    defaultSearchEngine: 'bing' | 'duckduckgo' | 'exa' | 'brave' | 'baidu' | 'csdn' | 'linuxdo'  | 'juejin' | 'startpage';
+    defaultSearchEngine: 'bing' | 'duckduckgo' | 'exa' | 'brave' | 'baidu' | 'csdn' | 'linuxdo'  | 'juejin' | 'startpage' | 'tavily';
     // List of allowed search engines (if empty, all engines are available)
     allowedSearchEngines: string[];
     // Search mode: request only, auto request then fallback, or force Playwright
@@ -19,6 +19,8 @@ export interface AppConfig {
     playwrightCdpEndpoint?: string;
     playwrightHeadless: boolean;
     playwrightNavigationTimeoutMs: number;
+    // Tavily configuration
+    tavilyApiKey?: string;
     // CORS configuration
     enableCors: boolean;
     corsOrigin: string;
@@ -51,6 +53,8 @@ export const config: AppConfig = {
     playwrightCdpEndpoint: readOptionalEnv('PLAYWRIGHT_CDP_ENDPOINT'),
     playwrightHeadless: process.env.PLAYWRIGHT_HEADLESS !== 'false',
     playwrightNavigationTimeoutMs: Number(process.env.PLAYWRIGHT_NAVIGATION_TIMEOUT_MS || 20000),
+    // Tavily configuration
+    tavilyApiKey: readOptionalEnv('TAVILY_API_KEY'),
     // CORS configuration
     enableCors: process.env.ENABLE_CORS === 'true',
     corsOrigin: process.env.CORS_ORIGIN || '*',
@@ -60,7 +64,7 @@ export const config: AppConfig = {
 };
 
 // Valid search engines list
-const validSearchEngines = ['bing', 'duckduckgo', 'exa', 'brave', 'baidu', 'csdn', 'linuxdo', 'juejin', 'startpage'];
+const validSearchEngines = ['bing', 'duckduckgo', 'exa', 'brave', 'baidu', 'csdn', 'linuxdo', 'juejin', 'startpage', 'tavily'];
 const validSearchModes = ['request', 'auto', 'playwright'];
 const validPlaywrightPackages = ['auto', 'playwright', 'playwright-core'];
 const quietStartupLogs = process.env.OPEN_WEBSEARCH_QUIET_STARTUP === 'true';

--- a/src/core/search/searchEngines.ts
+++ b/src/core/search/searchEngines.ts
@@ -7,7 +7,8 @@ export const SUPPORTED_SEARCH_ENGINES = [
     'exa',
     'brave',
     'juejin',
-    'startpage'
+    'startpage',
+    'tavily'
 ] as const;
 
 export type SupportedSearchEngine = typeof SUPPORTED_SEARCH_ENGINES[number];
@@ -35,6 +36,8 @@ export function normalizeEngineName(engine: string): string {
             return 'juejin';
         case 'startpage':
             return 'startpage';
+        case 'tavily':
+            return 'tavily';
         default:
             return cleaned;
     }

--- a/src/engines/tavily/tavily.ts
+++ b/src/engines/tavily/tavily.ts
@@ -1,0 +1,25 @@
+import { tavily } from '@tavily/core';
+import { SearchResult } from '../../types.js';
+import { config } from '../../config.js';
+
+export async function searchTavily(query: string, limit: number): Promise<SearchResult[]> {
+    const apiKey = config.tavilyApiKey;
+    if (!apiKey) {
+        throw new Error('TAVILY_API_KEY is not configured');
+    }
+
+    const client = tavily({ apiKey });
+    const response = await client.search(query, {
+        maxResults: Math.min(limit, 20),
+        searchDepth: 'basic',
+        topic: 'general',
+    });
+
+    return response.results.map((result) => ({
+        title: result.title || '',
+        url: result.url,
+        description: result.content || '',
+        source: new URL(result.url).hostname,
+        engine: 'tavily',
+    }));
+}

--- a/src/runtime/createRuntime.ts
+++ b/src/runtime/createRuntime.ts
@@ -8,6 +8,7 @@ import { searchExa } from '../engines/exa/index.js';
 import { searchBrave } from '../engines/brave/index.js';
 import { searchJuejin } from '../engines/juejin/index.js';
 import { searchStartpage } from '../engines/startpage/index.js';
+import { searchTavily } from '../engines/tavily/tavily.js';
 import { fetchLinuxDoArticle } from '../engines/linuxdo/fetchLinuxDoArticle.js';
 import { fetchCsdnArticle } from '../engines/csdn/fetchCsdnArticle.js';
 import { fetchJuejinArticle } from '../engines/juejin/fetchJuejinArticle.js';
@@ -39,7 +40,7 @@ export type CreateOpenWebSearchRuntimeOptions = {
 };
 
 function createDefaultSearchExecutors(): SearchEngineExecutorMap {
-    return {
+    const executors: SearchEngineExecutorMap = {
         baidu: searchBaidu,
         bing: searchBing,
         linuxdo: searchLinuxDo,
@@ -50,6 +51,12 @@ function createDefaultSearchExecutors(): SearchEngineExecutorMap {
         juejin: searchJuejin,
         startpage: searchStartpage
     };
+
+    if (config.tavilyApiKey) {
+        executors.tavily = searchTavily;
+    }
+
+    return executors;
 }
 
 export function createOpenWebSearchRuntime(options: CreateOpenWebSearchRuntimeOptions = {}): OpenWebSearchRuntime {


### PR DESCRIPTION
## Summary
- Added Tavily as an opt-in search engine alongside existing engines (Bing, DuckDuckGo, Brave, etc.)
- Tavily is selectable via `DEFAULT_SEARCH_ENGINE=tavily` or by including `'tavily'` in the engines list
- Tavily engine is silently skipped if `TAVILY_API_KEY` is not set, preserving zero-config behavior

## Files changed
- **package.json** — Added `@tavily/core` (^0.7.2) as a runtime dependency
- **src/config.ts** — Added `'tavily'` to `defaultSearchEngine` type union and `validSearchEngines` array; added `tavilyApiKey` field reading `TAVILY_API_KEY` from environment
- **src/core/search/searchEngines.ts** — Added `'tavily'` to `SUPPORTED_SEARCH_ENGINES` tuple and `normalizeEngineName` switch
- **src/engines/tavily/tavily.ts** — New file implementing `SearchEngineExecutor` using `@tavily/core`, mapping Tavily results to `SearchResult[]`
- **src/runtime/createRuntime.ts** — Registered Tavily executor in the engine map, conditional on `TAVILY_API_KEY` being set

## Dependency changes
- Added `@tavily/core` ^0.7.2 to `dependencies` in package.json

## Environment variable changes
- Added `TAVILY_API_KEY` (required to activate the Tavily engine)

## Notes for reviewers
- All existing engines are untouched — this is a purely additive change
- Tavily API limits max results to 20, so the executor caps the limit accordingly
- TypeScript compiles cleanly with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily engine integration is well-implemented and correct. The additive approach is consistent with the existing engine pattern. All required locations (config types, validation lists, searchEngines constants, normalizeEngineName switch, runtime registration) are updated. The `@tavily/core` SDK is used correctly, result mapping matches the `SearchResult` interface, and the conditional registration on `TAVILY_API_KEY` is the right pattern for optional API-key-gated engines. No regressions introduced.
