### PR TITLE
feat(search): add Sogou search engine support (close #78)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -115,6 +115,7 @@ MCP工具支持：
     - brave
     - juejin
     - startpage
+    - sogou
 - 支持HTTP代理配置，轻松解决网络访问限制
 - 无需API密钥或身份验证
 - 返回带标题、URL和描述的结构化结果
@@ -212,7 +213,7 @@ npm run search:cli -- "open web search" --json
 本地 daemon HTTP API（`serve`、`status`、`GET /health`、`POST /search`、`POST /fetch-*`）请参考 [docs/http-api.md](docs/http-api.md)。
 
 ## TODO
-- 支持~~Bing~~（已支持）,~~DuckDuckGo~~（已支持）,~~Exa~~（已支持）,~~Brave~~（已支持）,Google等搜索引擎
+- 支持~~Bing~~（已支持）,~~DuckDuckGo~~（已支持）,~~Exa~~（已支持）,~~Brave~~（已支持）,~~Sogou~~（已支持）,Google等搜索引擎
 - 支持更多博客论坛、社交软件
 - 优化文章内容提取功能，增加更多站点支持
 - ~~支持GitHub README获取~~（已支持）
@@ -250,7 +251,7 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 |--------|-------------------------|--------|--------------------------------------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | 启用CORS                               |
 | `CORS_ORIGIN` | `*`                     | 任何有效来源 | CORS来源配置                             |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage` | 默认搜索引擎                               |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | 默认搜索引擎                               |
 | `USE_PROXY` | `false`                 | `true`, `false` | 启用HTTP代理                             |
 | `PROXY_URL` | `http://127.0.0.1:7890` | 任何有效URL | 代理服务器URL                             |
 | `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | 仅对 `fetchWebContent` 关闭 TLS 证书校验。只建议在目标站点证书链异常时临时使用 |
@@ -508,7 +509,7 @@ docker run -d --name web-search -p 3000:3000 -e ENABLE_CORS=true -e CORS_ORIGIN=
 |--------|-------------------------|--------|------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | 启用CORS |
 | `CORS_ORIGIN` | `*`                     | 任何有效来源 | CORS来源配置 |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave` | 默认搜索引擎 |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | 默认搜索引擎 |
 | `USE_PROXY` | `false`                 | `true`, `false` | 启用HTTP代理 |
 | `PROXY_URL` | `http://127.0.0.1:7890` | 任何有效URL | 代理服务器URL |
 | `PORT` | `3000`                  | 1-65535 | 服务器端口 |
@@ -549,7 +550,7 @@ docker run -d --name web-search -p 3000:3000 -e ENABLE_CORS=true -e CORS_ORIGIN=
 {
   "query": string,        // 搜索查询词
   "limit": number,        // 可选：返回结果数量（默认：10）
-  "engines": string[],    // 可选：使用的引擎 (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage) 默认使用当前运行配置
+  "engines": string[],    // 可选：使用的引擎 (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage,sogou) 默认使用当前运行配置
   "searchMode": string    // 可选：request、auto 或 playwright（当前仅对 Bing 生效）
 }
 ```
@@ -562,7 +563,7 @@ use_mcp_tool({
   arguments: {
     query: "搜索内容",
     limit: 3,  // 可选参数
-    engines: ["bing", "csdn", "duckduckgo", "exa", "brave", "juejin"] // 可选参数，支持多引擎组合搜索
+    engines: ["bing", "csdn", "duckduckgo", "exa", "brave", "juejin", "sogou"] // 可选参数，支持多引擎组合搜索
   }
 })
 ```
@@ -772,7 +773,7 @@ use_mcp_tool({
 
 4. **搜索引擎配置**：
    - 可通过环境变量`DEFAULT_SEARCH_ENGINE`设置默认搜索引擎
-   - 支持的引擎有：bing, duckduckgo, exa, brave
+   - 支持的引擎有：bing, duckduckgo, exa, brave, baidu, csdn, juejin, startpage, sogou
    - 当搜索特定网站内容时，会自动使用默认搜索引擎
 
 5. **代理服务配置**：

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
     - brave
     - juejin
     - startpage
+    - sogou
 - HTTP proxy configuration support for accessing restricted resources
 - No API keys or authentication required
 - Returns structured results with titles, URLs, and descriptions
@@ -124,7 +125,7 @@ Notes:
 For the local daemon HTTP API (`serve`, `status`, `GET /health`, `POST /search`, `POST /fetch-*`), see [docs/http-api.md](docs/http-api.md).
 
 ## TODO
-- Support for ~~Bing~~ (already supported), ~~DuckDuckGo~~ (already supported), ~~Exa~~ (already supported), ~~Brave~~ (already supported), Google and other search engines
+- Support for ~~Bing~~ (already supported), ~~DuckDuckGo~~ (already supported), ~~Exa~~ (already supported), ~~Brave~~ (already supported), ~~Sogou~~ (already supported), Google and other search engines
 - Support for more blogs, forums, and social platforms
 - Optimize article content extraction, add support for more sites
 - ~~Support for GitHub README fetching~~ (already supported)
@@ -161,7 +162,7 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 |----------|-------------------------|---------|-------------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | Enable CORS |
 | `CORS_ORIGIN` | `*`                     | Any valid origin | CORS origin configuration |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage` | Default search engine |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | Default search engine |
 | `USE_PROXY` | `false`                 | `true`, `false` | Enable HTTP proxy |
 | `PROXY_URL` | `http://127.0.0.1:7890` | Any valid URL | Proxy server URL |
 | `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | Disable TLS certificate verification for `fetchWebContent` only. Use only when a target site has a broken certificate chain |
@@ -416,7 +417,7 @@ Environment variable configuration:
 |----------|-------------------------|---------|-------------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | Enable CORS |
 | `CORS_ORIGIN` | `*`                     | Any valid origin | CORS origin configuration |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave` | Default search engine |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | Default search engine |
 | `USE_PROXY` | `false`                 | `true`, `false` | Enable HTTP proxy |
 | `PROXY_URL` | `http://127.0.0.1:7890` | Any valid URL | Proxy server URL |
 | `PORT` | `3000`                  | 1-65535 | Server port |
@@ -457,7 +458,7 @@ For the local daemon HTTP API (`serve`, `status`, `GET /health`, `POST /search`,
 {
   "query": string,        // Search query
   "limit": number,        // Optional: Number of results to return (default: 10)
-  "engines": string[],    // Optional: Engines to use (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage) default runtime-configured engine
+  "engines": string[],    // Optional: Engines to use (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage,sogou) default runtime-configured engine
   "searchMode": string    // Optional: request, auto, or playwright (currently only affects Bing)
 }
 ```
@@ -470,7 +471,7 @@ use_mcp_tool({
   arguments: {
     query: "search content",
     limit: 3,  // Optional parameter
-    engines: ["bing", "csdn", "duckduckgo", "exa", "brave", "juejin"] // Optional parameter, supports multi-engine combined search
+    engines: ["bing", "csdn", "duckduckgo", "exa", "brave", "juejin", "sogou"] // Optional parameter, supports multi-engine combined search
   }
 })
 ```
@@ -675,7 +676,7 @@ Since this tool works by scraping multi-engine search results, please note the f
 
 4. **Search Engine Configuration**:
    - Default search engine can be set via the `DEFAULT_SEARCH_ENGINE` environment variable
-   - Supported engines: bing, duckduckgo, exa, brave
+   - Supported engines: bing, duckduckgo, exa, brave, baidu, csdn, juejin, startpage, sogou
    - The default engine is used when searching specific websites
 
 5. **Proxy Configuration**:

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -138,7 +138,7 @@ Request body:
 {
   "query": "open web search",
   "limit": 3,
-  "engines": ["startpage", "bing"],
+  "engines": ["startpage", "bing", "sogou"],
   "searchMode": "playwright"
 }
 ```
@@ -156,7 +156,7 @@ Example:
 ```bash
 curl --noproxy '*' -X POST http://127.0.0.1:3210/search \
   -H "Content-Type: application/json" \
-  -d '{"query":"open web search","limit":3,"engines":["bing"],"searchMode":"playwright"}'
+  -d '{"query":"open web search","limit":3,"engines":["sogou"]}'
 ```
 
 ### `POST /fetch-web`

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:local-daemon": "tsc && node build/test/test-local-daemon.js",
     "test:mcp-adapter": "tsc && node build/test/test-mcp-adapter.js",
     "test:runtime": "tsc && node build/test/test-runtime.js",
+    "test:sogou": "tsc && node build/test/test-sogou.js",
     "test:startpage": "tsc && node build/test/test-startpage.js",
     "test:http-request-options": "tsc && node build/test/test-http-request-options.js",
     "test:url-safety": "tsc && node build/test/test-url-safety.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 // src/config.ts
 export interface AppConfig {
     // Search engine configuration
-    defaultSearchEngine: 'bing' | 'duckduckgo' | 'exa' | 'brave' | 'baidu' | 'csdn' | 'linuxdo'  | 'juejin' | 'startpage';
+    defaultSearchEngine: 'bing' | 'duckduckgo' | 'exa' | 'brave' | 'baidu' | 'csdn' | 'linuxdo'  | 'juejin' | 'startpage' | 'sogou';
     // List of allowed search engines (if empty, all engines are available)
     allowedSearchEngines: string[];
     // Search mode: request only, auto request then fallback, or force Playwright
@@ -60,7 +60,7 @@ export const config: AppConfig = {
 };
 
 // Valid search engines list
-const validSearchEngines = ['bing', 'duckduckgo', 'exa', 'brave', 'baidu', 'csdn', 'linuxdo', 'juejin', 'startpage'];
+const validSearchEngines = ['bing', 'duckduckgo', 'exa', 'brave', 'baidu', 'csdn', 'linuxdo', 'juejin', 'startpage', 'sogou'];
 const validSearchModes = ['request', 'auto', 'playwright'];
 const validPlaywrightPackages = ['auto', 'playwright', 'playwright-core'];
 const quietStartupLogs = process.env.OPEN_WEBSEARCH_QUIET_STARTUP === 'true';

--- a/src/core/search/searchEngines.ts
+++ b/src/core/search/searchEngines.ts
@@ -7,7 +7,8 @@ export const SUPPORTED_SEARCH_ENGINES = [
     'exa',
     'brave',
     'juejin',
-    'startpage'
+    'startpage',
+    'sogou'
 ] as const;
 
 export type SupportedSearchEngine = typeof SUPPORTED_SEARCH_ENGINES[number];
@@ -35,6 +36,10 @@ export function normalizeEngineName(engine: string): string {
             return 'juejin';
         case 'startpage':
             return 'startpage';
+        case 'sogou':
+        case 'sougou':
+        case '搜狗':
+            return 'sogou';
         default:
             return cleaned;
     }

--- a/src/engines/sogou/index.ts
+++ b/src/engines/sogou/index.ts
@@ -1,0 +1,1 @@
+export { __setSogouHttpGetForTests, parseSogouSearchResults, searchSogou } from './sogou.js';

--- a/src/engines/sogou/sogou.ts
+++ b/src/engines/sogou/sogou.ts
@@ -1,0 +1,222 @@
+import axios from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as cheerio from 'cheerio';
+import { SearchResult } from '../../types.js';
+import { buildAxiosRequestOptions } from '../../utils/httpRequest.js';
+
+const SOGOU_SEARCH_URL = 'https://www.sogou.com/web';
+const SOGOU_PAGE_SIZE = 10;
+
+const COMMON_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+    'Referer': 'https://www.sogou.com/'
+};
+
+type SogouHttpGet = (url: string, options: AxiosRequestConfig) => Promise<AxiosResponse>;
+
+let sogouHttpGet: SogouHttpGet = (url, options) => axios.get(url, options);
+
+export function __setSogouHttpGetForTests(impl?: SogouHttpGet): void {
+    sogouHttpGet = impl ?? ((url, options) => axios.get(url, options));
+}
+
+function normalizeText(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+function isSogouChallengePage(html: string): boolean {
+    const normalized = html.toLowerCase();
+    const $ = cheerio.load(html);
+    const title = $('title').first().text().trim();
+
+    return normalized.includes('antispider')
+        || normalized.includes('请输入验证码')
+        || normalized.includes('访问过于频繁')
+        || title.includes('搜狗搜索验证');
+}
+
+function resolveResultUrl(rawUrl: string): string {
+    const trimmed = rawUrl.trim();
+    if (!trimmed) {
+        return '';
+    }
+
+    try {
+        const absoluteUrl = new URL(trimmed, SOGOU_SEARCH_URL).toString();
+        const parsed = new URL(absoluteUrl);
+        const target = parsed.searchParams.get('url') || parsed.searchParams.get('u') || parsed.searchParams.get('link');
+        if (target && /^https?:\/\//i.test(target)) {
+            return target;
+        }
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+            return absoluteUrl;
+        }
+    } catch {
+        return '';
+    }
+
+    return '';
+}
+
+function extractSource(url: string, sourceText: string): string {
+    const cleanedSource = normalizeText(sourceText);
+    if (cleanedSource) {
+        return cleanedSource;
+    }
+
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return '';
+    }
+}
+
+function isAllowedSogouRedirectUrl(url: URL): boolean {
+    const hostname = url.hostname.toLowerCase();
+    return (url.protocol === 'https:' || url.protocol === 'http:')
+        && (hostname === 'sogou.com' || hostname.endsWith('.sogou.com'));
+}
+
+function mergeSetCookie(cookieHeader: string, setCookie: string | string[] | undefined): string {
+    if (!setCookie) {
+        return cookieHeader;
+    }
+
+    const cookieMap = new Map<string, string>();
+    for (const cookie of cookieHeader.split(';')) {
+        const trimmed = cookie.trim();
+        if (!trimmed) {
+            continue;
+        }
+        const [name] = trimmed.split('=', 1);
+        cookieMap.set(name, trimmed);
+    }
+
+    const values = Array.isArray(setCookie) ? setCookie : [setCookie];
+    for (const value of values) {
+        const pair = value.split(';', 1)[0]?.trim();
+        if (!pair) {
+            continue;
+        }
+        const [name] = pair.split('=', 1);
+        cookieMap.set(name, pair);
+    }
+
+    return Array.from(cookieMap.values()).join('; ');
+}
+
+async function fetchSogouHtml(initialUrl: string): Promise<string> {
+    let currentUrl = initialUrl;
+    let cookieHeader = '';
+
+    for (let redirects = 0; redirects <= 5; redirects += 1) {
+        const response = await sogouHttpGet(currentUrl, buildAxiosRequestOptions({
+            trustedStaticHost: true,
+            headers: {
+                ...COMMON_HEADERS,
+                ...(cookieHeader ? { Cookie: cookieHeader } : {})
+            },
+            timeout: 20000,
+            validateStatus: (status) => status >= 200 && status < 400
+        }));
+
+        cookieHeader = mergeSetCookie(cookieHeader, response.headers?.['set-cookie']);
+
+        if (response.status >= 300 && response.status < 400) {
+            const location = response.headers?.location;
+            if (!location) {
+                throw new Error(`Sogou returned redirect status ${response.status} without a Location header`);
+            }
+
+            const redirectUrl = new URL(String(location), currentUrl);
+            if (!isAllowedSogouRedirectUrl(redirectUrl)) {
+                throw new Error(`Sogou redirected to an unexpected host: ${redirectUrl.hostname}`);
+            }
+            currentUrl = redirectUrl.toString();
+            continue;
+        }
+
+        return String(response.data || '');
+    }
+
+    throw new Error('Sogou returned too many redirects');
+}
+
+export function parseSogouSearchResults(html: string): SearchResult[] {
+    if (isSogouChallengePage(html)) {
+        throw new Error('Sogou returned a verification or anti-bot page');
+    }
+
+    const $ = cheerio.load(html);
+    const results: SearchResult[] = [];
+    const seenUrls = new Set<string>();
+
+    const resultSelectors = [
+        '#main .vrwrap',
+        '#main .rb',
+        '#main .result',
+        '#results .vrwrap',
+        '.results .vrwrap',
+        '.results .rb'
+    ].join(',');
+
+    $(resultSelectors).each((_, element) => {
+        const card = $(element);
+        const titleLink = card.find('h3 a[href], h2 a[href], .vr-title a[href], .pt a[href]').first();
+        const rawUrl = titleLink.attr('href') || '';
+        const url = resolveResultUrl(rawUrl);
+        const title = normalizeText(titleLink.text());
+
+        if (!title || !url || seenUrls.has(url)) {
+            return;
+        }
+
+        const description = normalizeText(card.find('.str_info, .ft, .text-layout, .fz-mid, p').first().text());
+        const source = extractSource(url, card.find('cite, .citeurl, .g, .url').first().text());
+
+        seenUrls.add(url);
+        results.push({
+            title,
+            url,
+            description,
+            source,
+            engine: 'sogou'
+        });
+    });
+
+    return results;
+}
+
+async function searchSogouPage(query: string, page: number): Promise<SearchResult[]> {
+    const url = new URL(SOGOU_SEARCH_URL);
+    url.searchParams.set('query', query);
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('ie', 'utf8');
+
+    return parseSogouSearchResults(await fetchSogouHtml(url.toString()));
+}
+
+export async function searchSogou(query: string, limit: number): Promise<SearchResult[]> {
+    const allResults: SearchResult[] = [];
+    const seenUrls = new Set<string>();
+    const maxPage = Math.max(1, Math.ceil(limit / SOGOU_PAGE_SIZE));
+
+    for (let page = 1; page <= maxPage && allResults.length < limit; page += 1) {
+        const pageResults = await searchSogouPage(query, page);
+        for (const result of pageResults) {
+            if (seenUrls.has(result.url)) {
+                continue;
+            }
+            seenUrls.add(result.url);
+            allResults.push(result);
+        }
+
+        if (pageResults.length === 0) {
+            break;
+        }
+    }
+
+    return allResults.slice(0, limit);
+}

--- a/src/runtime/createRuntime.ts
+++ b/src/runtime/createRuntime.ts
@@ -8,6 +8,7 @@ import { searchExa } from '../engines/exa/index.js';
 import { searchBrave } from '../engines/brave/index.js';
 import { searchJuejin } from '../engines/juejin/index.js';
 import { searchStartpage } from '../engines/startpage/index.js';
+import { searchSogou } from '../engines/sogou/index.js';
 import { fetchLinuxDoArticle } from '../engines/linuxdo/fetchLinuxDoArticle.js';
 import { fetchCsdnArticle } from '../engines/csdn/fetchCsdnArticle.js';
 import { fetchJuejinArticle } from '../engines/juejin/fetchJuejinArticle.js';
@@ -48,7 +49,8 @@ function createDefaultSearchExecutors(): SearchEngineExecutorMap {
         exa: searchExa,
         brave: searchBrave,
         juejin: searchJuejin,
-        startpage: searchStartpage
+        startpage: searchStartpage,
+        sogou: searchSogou
     };
 }
 

--- a/src/test/test-cli-search.ts
+++ b/src/test/test-cli-search.ts
@@ -122,6 +122,15 @@ function testParseSearchArgs(): void {
     );
     assertEqual(parsedWithSearchMode.searchMode, 'playwright', 'parsed search mode');
 
+    const parsedSogouAlias = parseSearchArgs(
+        ['Open', 'WebSearch', '--engine', 'sou-gou'],
+        createStubRuntime({
+            defaultSearchEngine: 'sogou',
+            allowedSearchEngines: ['sogou']
+        })
+    );
+    assertEqual(parsedSogouAlias.engines.join(','), 'sogou', 'parsed Sogou alias');
+
     console.log('✅ CLI parseSearchArgs');
 }
 

--- a/src/test/test-core-search.ts
+++ b/src/test/test-core-search.ts
@@ -44,6 +44,8 @@ function testNormalizeEngineName(): void {
     assertEqual(normalizeEngineName('duck-duck-go'), 'duckduckgo', 'normalizes duckduckgo alias');
     assertEqual(normalizeEngineName('linux.do'), 'linuxdo', 'normalizes linux.do alias');
     assertEqual(normalizeEngineName('StartPage'), 'startpage', 'normalizes StartPage');
+    assertEqual(normalizeEngineName('sou-gou'), 'sogou', 'normalizes sou-gou alias');
+    assertEqual(normalizeEngineName('搜狗'), 'sogou', 'normalizes Chinese Sogou alias');
     assertEqualArray([...SUPPORTED_SEARCH_ENGINES], [
         'baidu',
         'bing',
@@ -53,7 +55,8 @@ function testNormalizeEngineName(): void {
         'exa',
         'brave',
         'juejin',
-        'startpage'
+        'startpage',
+        'sogou'
     ], 'supported engines list');
     console.log('✅ normalizeEngineName and supported engines');
 }

--- a/src/test/test-engine-normalization.ts
+++ b/src/test/test-engine-normalization.ts
@@ -10,7 +10,8 @@ const SUPPORTED_ENGINES = [
     'exa',
     'brave',
     'juejin',
-    'startpage'
+    'startpage',
+    'sogou'
 ] as const;
 
 const engineSchema = z.array(
@@ -37,7 +38,10 @@ const successCases: SuccessCase[] = [
     { input: ['duck-duck-go'], expected: ['duckduckgo'] },
     { input: ['linux.do'], expected: ['linuxdo'] },
     { input: ['  CSDN  ', 'JueJin'], expected: ['csdn', 'juejin'] },
-    { input: ['StartPage'], expected: ['startpage'] }
+    { input: ['StartPage'], expected: ['startpage'] },
+    { input: ['SouGou'], expected: ['sogou'] },
+    { input: ['sou-gou'], expected: ['sogou'] },
+    { input: ['搜狗'], expected: ['sogou'] }
 ];
 
 const failureCases: FailureCase[] = [

--- a/src/test/test-mcp-adapter.ts
+++ b/src/test/test-mcp-adapter.ts
@@ -125,7 +125,7 @@ async function testSetupToolsUsesRuntimeConfigDefaults(): Promise<void> {
     const runtime = createOpenWebSearchRuntime({
         config: createTestConfig({
             defaultSearchEngine: 'startpage',
-            allowedSearchEngines: ['startpage', 'bing']
+            allowedSearchEngines: ['startpage', 'bing', 'sogou']
         }),
         dependencies: {
             searchExecutors: {
@@ -142,6 +142,13 @@ async function testSetupToolsUsesRuntimeConfigDefaults(): Promise<void> {
                     description: `${query}:${limit}`,
                     source: 'example.com',
                     engine: 'bing'
+                }],
+                sogou: async (query, limit) => [{
+                    title: 'Sogou Result',
+                    url: 'https://sogou.example.com',
+                    description: `${query}:${limit}`,
+                    source: 'sogou.example.com',
+                    engine: 'sogou'
                 }]
             },
             fetchGithubReadme: async () => '# README',
@@ -182,6 +189,7 @@ async function testSetupToolsUsesRuntimeConfigDefaults(): Promise<void> {
     assertEqual(payload.engines[0], 'startpage', 'search handler should use runtime default engine');
     assertEqual(payload.results[0].engine, 'startpage', 'search execution should respect runtime default engine');
     assert(tools.search.description.includes('Startpage'), 'search description should use runtime-config allowed engines');
+    assert(tools.search.description.includes('Sogou'), 'search description should include Sogou when allowed');
 
     console.log('✅ setupTools uses runtime.config defaults');
 }

--- a/src/test/test-sogou.ts
+++ b/src/test/test-sogou.ts
@@ -1,0 +1,144 @@
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { __setSogouHttpGetForTests, parseSogouSearchResults, searchSogou } from '../engines/sogou/index.js';
+
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+    if (actual !== expected) {
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+    }
+}
+
+function makeResponse(status: number, headers: Record<string, string | string[]>, data: string): AxiosResponse {
+    return {
+        status,
+        statusText: String(status),
+        headers,
+        data,
+        config: {} as AxiosResponse['config']
+    };
+}
+
+function testParseSogouResults(): void {
+    const html = `
+        <html>
+          <body>
+            <div id="main">
+              <div class="vrwrap">
+                <h3 class="vr-title">
+                  <a href="https://example.com/open-websearch"> Open-WebSearch </a>
+                </h3>
+                <div class="str_info"> MCP server and CLI search demo. </div>
+                <cite>example.com</cite>
+              </div>
+              <div class="vrwrap">
+                <h3 class="vr-title">
+                  <a href="/link?url=https%3A%2F%2Fdocs.example.com%2Fguide"> Docs Guide </a>
+                </h3>
+                <p> Project documentation and setup guide. </p>
+              </div>
+              <div class="vrwrap">
+                <h3 class="vr-title">
+                  <a href="https://example.com/open-websearch"> Duplicate </a>
+                </h3>
+                <div class="str_info">Duplicate should be skipped.</div>
+              </div>
+              <div class="vrwrap">
+                <h3 class="vr-title"><a href=""> Missing URL </a></h3>
+              </div>
+              <div class="vrwrap">
+                <h3 class="vr-title"><a href="javascript:void(0)"> Script URL </a></h3>
+              </div>
+            </div>
+          </body>
+        </html>
+    `;
+
+    const results = parseSogouSearchResults(html);
+
+    assertEqual(results.length, 2, 'parsed result count');
+    assertEqual(results[0].title, 'Open-WebSearch', 'first title');
+    assertEqual(results[0].url, 'https://example.com/open-websearch', 'first url');
+    assertEqual(results[0].description, 'MCP server and CLI search demo.', 'first description');
+    assertEqual(results[0].source, 'example.com', 'first source');
+    assertEqual(results[0].engine, 'sogou', 'first engine');
+    assertEqual(results[1].title, 'Docs Guide', 'second title');
+    assertEqual(results[1].url, 'https://docs.example.com/guide', 'decoded redirect url');
+    assertEqual(results[1].source, 'docs.example.com', 'second source falls back to hostname');
+
+    console.log('✅ parse Sogou HTML results');
+}
+
+function testSogouChallengeDetection(): void {
+    let threw = false;
+    try {
+        parseSogouSearchResults('<html><title>搜狗搜索验证</title><body>请输入验证码</body></html>');
+    } catch (error) {
+        threw = error instanceof Error && error.message.includes('verification');
+    }
+
+    assert(threw, 'Sogou challenge page should throw a verification error');
+    console.log('✅ detect Sogou verification page');
+}
+
+async function testSearchSogouFollowsRedirects(): Promise<void> {
+    const requestedUrls: string[] = [];
+    const requestedCookies: Array<string | undefined> = [];
+
+    __setSogouHttpGetForTests(async (url: string, options: AxiosRequestConfig) => {
+        requestedUrls.push(url);
+        requestedCookies.push((options.headers as Record<string, string> | undefined)?.Cookie);
+
+        if (requestedUrls.length === 1) {
+            return makeResponse(
+                302,
+                {
+                    location: '/web?query=%E5%8C%97%E4%BA%AC&page=1&ie=utf8',
+                    'set-cookie': ['SNUID=test-cookie; path=/']
+                },
+                ''
+            );
+        }
+
+        return makeResponse(
+            200,
+            {},
+            `
+                <div id="main">
+                  <div class="vrwrap">
+                    <h3 class="vr-title"><a href="https://example.com/beijing">Beijing</a></h3>
+                    <div class="str_info">Capital city.</div>
+                  </div>
+                </div>
+            `
+        );
+    });
+
+    try {
+        const results = await searchSogou('北京', 1);
+        assertEqual(results.length, 1, 'redirect search result count');
+        assertEqual(results[0].title, 'Beijing', 'redirect search result title');
+        assertEqual(requestedUrls.length, 2, 'Sogou search should follow one redirect');
+        assert(requestedUrls[0].startsWith('https://www.sogou.com/web?'), 'first request should use Sogou web endpoint');
+        assertEqual(requestedCookies[1], 'SNUID=test-cookie', 'redirect request should carry Sogou cookie');
+        console.log('✅ Sogou search follows safe redirects');
+    } finally {
+        __setSogouHttpGetForTests();
+    }
+}
+
+async function main(): Promise<void> {
+    testParseSogouResults();
+    testSogouChallengeDetection();
+    await testSearchSogouFollowsRedirects();
+    console.log('\nSogou tests passed.');
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/src/tools/setupTools.ts
+++ b/src/tools/setupTools.ts
@@ -45,7 +45,7 @@ export const setupTools = (server: McpServer, runtime: OpenWebSearchRuntime): vo
         // 明确 auto/省略会使用服务端 SEARCH_MODE，只有 request/playwright 才是强制覆盖。
         const searchModeDescription = ' searchMode meanings: omit or set auto to use the server configured SEARCH_MODE; request forces request-based search; playwright forces browser-based search.';
         if (runtime.config.allowedSearchEngines.length === 0) {
-            return `Search the web using multiple engines (e.g., Baidu, Bing, DuckDuckGo, CSDN, Exa, Brave, Juejin(掘金), Startpage) with no API key required.${searchModeDescription}`;
+            return `Search the web using multiple engines (e.g., Baidu, Bing, DuckDuckGo, CSDN, Exa, Brave, Juejin(掘金), Startpage, Sogou(搜狗)) with no API key required.${searchModeDescription}`;
         } else {
             const enginesText = runtime.config.allowedSearchEngines.map(e => {
                 switch (e) {
@@ -53,6 +53,8 @@ export const setupTools = (server: McpServer, runtime: OpenWebSearchRuntime): vo
                         return 'Juejin(掘金)';
                     case 'startpage':
                         return 'Startpage';
+                    case 'sogou':
+                        return 'Sogou(搜狗)';
                     default:
                         return e.charAt(0).toUpperCase() + e.slice(1);
                 }


### PR DESCRIPTION
  ## Summary

  This PR adds Sogou (`sogou`) as a supported web search engine, addressing #78.

  The new engine is integrated into the existing search flow for MCP, CLI, and local HTTP daemon usage.

  ## Changes

  - Add Sogou web search implementation using `https://www.sogou.com/web`
  - Parse Sogou result cards into the shared `SearchResult` shape
  - Support Sogou redirects and cookies to handle the initial 302 response
  - Detect Sogou verification / anti-bot pages and return a clear engine error
  - Register `sogou` in:
    - supported search engine list
    - default/allowed engine validation
    - runtime search executor map
    - MCP search tool description
    - CLI / HTTP shared engine normalization
  - Support aliases:
    - `sogou`
    - `SouGou`
    - `sou-gou`
    - `搜狗`