### PR TITLE
fix: resolve Bing 301 redirect and Baidu TLS handshake failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "tsc && node build/tools/runCurrentTests.js",
     "test:list": "tsc && node build/tools/runCurrentTests.js --list",
     "test:bing-parser": "tsc && node build/test/test-bing-parser.js",
+    "test:bing-http": "tsc && node build/test/test-bing-http.js",
     "test:cli": "tsc && node build/test/test-cli-search.js",
     "test:cli-search": "tsc && node build/test/test-cli-search.js",
     "test:core-search": "tsc && node build/test/test-core-search.js",

--- a/src/engines/baidu/baidu.ts
+++ b/src/engines/baidu/baidu.ts
@@ -97,6 +97,9 @@ async function searchBaiduPage(query: string, page: number): Promise<SearchResul
     // 避免把 wappass 验证码跳转误当成正常结果页解析出 0 条。
     const response = await baiduHttpGet(url.toString(), buildAxiosRequestOptions({
         trustedStaticHost: true,
+        // 部分百度 CDN 边缘路径在默认 TLS 协商时会重置连接；仅在百度请求中排除
+        // TLS 1.3 提议，避免降低其他固定可信域名的 TLS 能力。
+        tlsMaxVersion: 'TLSv1.2',
         headers: COMMON_HEADERS,
         timeout: 20000,
         validateStatus: (status) => status >= 200 && status < 400,

--- a/src/engines/bing/bing.ts
+++ b/src/engines/bing/bing.ts
@@ -6,7 +6,7 @@ import { parseBingSearchResults } from './parser.js';
 import { acquirePooledPlaywrightPage, getPlaywrightModuleSource, loadPlaywrightClient, openPlaywrightBrowser } from '../../utils/playwrightClient.js';
 import { buildAxiosRequestOptions as buildSharedAxiosRequestOptions } from '../../utils/httpRequest.js';
 
-const BING_BASE_URL = 'https://cn.bing.com/search';
+const BING_BASE_URL = 'https://www.bing.com/search';
 const BING_HOME_URL = 'https://www.bing.com/?mkt=zh-CN';
 const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const SEARCH_INPUT_SELECTORS = [

--- a/src/engines/bing/bing.ts
+++ b/src/engines/bing/bing.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as cheerio from 'cheerio';
 import { AppConfig, config, getEffectiveSearchMode, checkPlaywrightModeConfiguration } from '../../config.js';
 import { SearchResult } from '../../types.js';
@@ -8,6 +9,8 @@ import { buildAxiosRequestOptions as buildSharedAxiosRequestOptions } from '../.
 
 const BING_BASE_URL = 'https://cn.bing.com/search';
 const BING_HOME_URL = 'https://www.bing.com/?mkt=zh-CN';
+const BING_REGIONAL_HOSTS = new Set(['cn.bing.com', 'www.bing.com']);
+const BING_MAX_REGIONAL_REDIRECTS = 1;
 const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const SEARCH_INPUT_SELECTORS = [
     'input[name="q"]',
@@ -56,6 +59,14 @@ const BROWSER_CONTEXT_OPTIONS = {
     deviceScaleFactor: 1,
     colorScheme: 'light'
 };
+
+type BingHttpGet = (url: string, options: AxiosRequestConfig) => Promise<AxiosResponse>;
+
+let bingHttpGet: BingHttpGet = (url, options) => axios.get(url, options);
+
+export function __setBingHttpGetForTests(impl?: BingHttpGet): void {
+    bingHttpGet = impl ?? ((url, options) => axios.get(url, options));
+}
 
 export function hasSiteOperator(query: string): boolean {
     return /(^|\s)site:[^\s]+/i.test(query);
@@ -120,8 +131,48 @@ function buildBingAxiosRequestOptions(): any {
     return buildSharedAxiosRequestOptions({
         trustedStaticHost: true,
         headers: FALLBACK_HEADERS,
-        timeout: config.playwrightNavigationTimeoutMs
+        timeout: config.playwrightNavigationTimeoutMs,
+        validateStatus: (status) => status >= 200 && status < 400
     });
+}
+
+function resolveBingRegionalRedirect(currentUrl: string, location: unknown): string {
+    if (typeof location !== 'string' || !location.trim()) {
+        throw new Error('Bing returned a redirect without a Location header');
+    }
+
+    const redirectUrl = new URL(location, currentUrl);
+    const hostname = redirectUrl.hostname.toLowerCase();
+    if (
+        redirectUrl.protocol !== 'https:'
+        || (redirectUrl.port && redirectUrl.port !== '443')
+        || redirectUrl.username
+        || redirectUrl.password
+        || !BING_REGIONAL_HOSTS.has(hostname)
+    ) {
+        throw new Error(`Bing redirected to an unsupported target: ${redirectUrl.toString()}`);
+    }
+
+    return redirectUrl.toString();
+}
+
+async function requestBingSearchPage(initialUrl: string): Promise<AxiosResponse> {
+    let currentUrl = initialUrl;
+
+    for (let redirectCount = 0; redirectCount <= BING_MAX_REGIONAL_REDIRECTS; redirectCount += 1) {
+        const response = await bingHttpGet(currentUrl, buildBingAxiosRequestOptions());
+        if (response.status < 300 || response.status >= 400) {
+            return response;
+        }
+
+        if (redirectCount === BING_MAX_REGIONAL_REDIRECTS) {
+            throw new Error(`Bing exceeded the regional redirect limit (${BING_MAX_REGIONAL_REDIRECTS})`);
+        }
+
+        currentUrl = resolveBingRegionalRedirect(currentUrl, response.headers?.location);
+    }
+
+    throw new Error('Bing request did not produce a final response');
 }
 
 let playwrightAvailabilityPromise: Promise<boolean> | null = null;
@@ -598,7 +649,7 @@ async function searchBingWithHttp(query: string, limit: number): Promise<SearchR
     let pageNumber = 0;
 
     while (allResults.length < limit) {
-        const response = await axios.get(buildBingSearchUrl(query, pageNumber), buildBingAxiosRequestOptions());
+        const response = await requestBingSearchPage(buildBingSearchUrl(query, pageNumber));
         const html = String(response.data || '');
 
         const pageState = analyzeBlockedPage(html);

--- a/src/engines/bing/index.ts
+++ b/src/engines/bing/index.ts
@@ -1,1 +1,1 @@
-export { searchBing } from './bing.js';
+export { __setBingHttpGetForTests, searchBing } from './bing.js';

--- a/src/engines/bing/parser.ts
+++ b/src/engines/bing/parser.ts
@@ -56,7 +56,7 @@ function sanitizeBingUrl(rawUrl?: string): string {
         if (resolvedUrl.startsWith('/search') || resolvedUrl.startsWith('/ck/a') || resolvedUrl.startsWith('/newtabredir')) {
             return '';
         }
-        resolvedUrl = `https://cn.bing.com${resolvedUrl}`;
+        resolvedUrl = `https://www.bing.com${resolvedUrl}`;
     }
 
     if (!resolvedUrl.startsWith('http://') && !resolvedUrl.startsWith('https://')) {

--- a/src/test/test-baidu.ts
+++ b/src/test/test-baidu.ts
@@ -1,4 +1,5 @@
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import https from 'node:https';
 import { __setBaiduHttpGetForTests, parseBaiduSearchResults, searchBaidu } from '../engines/baidu/index.js';
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -98,8 +99,10 @@ async function testSearchBaiduDetectsCaptchaRedirect(): Promise<void> {
 
 async function testSearchBaiduParsesResults(): Promise<void> {
     const requestedUrls: string[] = [];
-    __setBaiduHttpGetForTests(async (url: string, _options: AxiosRequestConfig) => {
+    const requestedOptions: AxiosRequestConfig[] = [];
+    __setBaiduHttpGetForTests(async (url: string, options: AxiosRequestConfig) => {
         requestedUrls.push(url);
+        requestedOptions.push(options);
         return makeResponse(
             200,
             {},
@@ -121,6 +124,9 @@ async function testSearchBaiduParsesResults(): Promise<void> {
         assert(requestedUrls.length === 1, 'Baidu search should make one request');
         assert(requestedUrls[0].startsWith('https://www.baidu.com/s?'), 'request should use Baidu search endpoint');
         assert(requestedUrls[0].includes('tn=88093251_62_hao_pg'), 'request should carry the stable hao123 tn');
+        assert(requestedOptions[0].httpsAgent instanceof https.Agent, 'Baidu search should use a dedicated https agent');
+        assert((requestedOptions[0].httpsAgent as any).options.maxVersion === 'TLSv1.2', 'Baidu search should omit TLS 1.3 from negotiation for incompatible CDN edges');
+        assert((requestedOptions[0].httpsAgent as any).options.rejectUnauthorized === true, 'Baidu TLS compatibility agent should keep certificate verification enabled');
         console.log('✅ Baidu search parses results and keeps the stable tn');
     } finally {
         __setBaiduHttpGetForTests();

--- a/src/test/test-bing-http.ts
+++ b/src/test/test-bing-http.ts
@@ -1,0 +1,129 @@
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { __setBingHttpGetForTests, searchBing } from '../engines/bing/index.js';
+
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function makeResponse(status: number, headers: Record<string, string>, data: string): AxiosResponse {
+    return {
+        status,
+        statusText: String(status),
+        headers,
+        data,
+        config: {} as AxiosResponse['config']
+    };
+}
+
+const resultHtml = `
+<ol id="b_results">
+  <li class="b_algo">
+    <h2><a href="https://example.com/result">Regional result</a></h2>
+    <div class="b_caption"><p>Result returned after regional routing.</p></div>
+  </li>
+</ol>`;
+
+async function testDirectRegionalEndpoint(): Promise<void> {
+    const requestedUrls: string[] = [];
+    __setBingHttpGetForTests(async (url: string, options: AxiosRequestConfig) => {
+        requestedUrls.push(url);
+        assert(options.maxRedirects === 0, 'Bing must keep automatic redirects disabled');
+        return makeResponse(200, {}, resultHtml);
+    });
+
+    try {
+        const results = await searchBing('test', 1, { searchMode: 'request' });
+        assert(results.length === 1, 'direct regional endpoint should return one result');
+        assert(requestedUrls.length === 1, 'direct regional endpoint should require one request');
+        assert(new URL(requestedUrls[0]).hostname === 'cn.bing.com', 'Bing should retain the China endpoint as its initial regional route');
+    } finally {
+        __setBingHttpGetForTests();
+    }
+
+    console.log('✅ Bing keeps the direct regional endpoint when it returns 200');
+}
+
+async function testAllowedRegionalRedirect(): Promise<void> {
+    const requestedUrls: string[] = [];
+    __setBingHttpGetForTests(async (url: string, options: AxiosRequestConfig) => {
+        requestedUrls.push(url);
+        assert(options.maxRedirects === 0, 'Bing regional routing must be handled explicitly');
+        if (requestedUrls.length === 1) {
+            assert(options.validateStatus?.(301) === true, 'Bing request should expose regional redirects to the caller');
+            return makeResponse(301, {
+                location: 'https://www.bing.com/?q=test&setlang=zh-CN&ensearch=0&first=1&mkt=zh-CN'
+            }, '');
+        }
+        return makeResponse(200, {}, resultHtml);
+    });
+
+    try {
+        const results = await searchBing('test', 1, { searchMode: 'request' });
+        assert(results.length === 1, 'allowed regional redirect should return one result');
+        assert(requestedUrls.length === 2, 'allowed regional redirect should make exactly two requests');
+        assert(new URL(requestedUrls[1]).hostname === 'www.bing.com', 'Bing should follow a redirect to the alternate regional host');
+    } finally {
+        __setBingHttpGetForTests();
+    }
+
+    console.log('✅ Bing follows one allowlisted regional redirect');
+}
+
+async function testUnsupportedRedirectRejected(): Promise<void> {
+    let requestCount = 0;
+    __setBingHttpGetForTests(async () => {
+        requestCount += 1;
+        return makeResponse(302, { location: 'https://example.com/search?q=test' }, '');
+    });
+
+    try {
+        await searchBing('test', 1, { searchMode: 'request' });
+        throw new Error('Bing should reject a redirect outside its regional host allowlist');
+    } catch (error) {
+        assert(error instanceof Error && error.message.includes('unsupported target'), 'unsupported redirect should report a clear error');
+        assert(requestCount === 1, 'unsupported redirect target must not receive a request');
+    } finally {
+        __setBingHttpGetForTests();
+    }
+
+    console.log('✅ Bing rejects redirects outside the regional host allowlist');
+}
+
+async function testRegionalRedirectLoopRejected(): Promise<void> {
+    let requestCount = 0;
+    __setBingHttpGetForTests(async (url: string) => {
+        requestCount += 1;
+        const hostname = new URL(url).hostname;
+        const location = hostname === 'cn.bing.com'
+            ? 'https://www.bing.com/search?q=test'
+            : 'https://cn.bing.com/search?q=test';
+        return makeResponse(302, { location }, '');
+    });
+
+    try {
+        await searchBing('test', 1, { searchMode: 'request' });
+        throw new Error('Bing should reject a regional redirect loop');
+    } catch (error) {
+        assert(error instanceof Error && error.message.includes('redirect limit'), 'regional redirect loop should report the redirect limit');
+        assert(requestCount === 2, 'regional redirect loop should stop after one followed redirect');
+    } finally {
+        __setBingHttpGetForTests();
+    }
+
+    console.log('✅ Bing bounds regional redirects to one hop');
+}
+
+async function main(): Promise<void> {
+    await testDirectRegionalEndpoint();
+    await testAllowedRegionalRedirect();
+    await testUnsupportedRedirectRejected();
+    await testRegionalRedirectLoopRejected();
+    console.log('\nBing HTTP tests passed.');
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/src/test/test-http-request-options.ts
+++ b/src/test/test-http-request-options.ts
@@ -35,6 +35,15 @@ function main(): void {
         assert(trustedStaticHostOptions.maxRedirects === 0, 'trusted static host requests should force redirects off');
         console.log('✅ trusted static host request options bypass DNS private-network filtering and force redirects off');
 
+        const tlsBoundTrustedStaticHostOptions = buildAxiosRequestOptions({
+            trustedStaticHost: true,
+            tlsMaxVersion: 'TLSv1.2'
+        });
+        assert(tlsBoundTrustedStaticHostOptions.httpsAgent instanceof https.Agent, 'TLS-bound trusted static host requests should use a direct https agent');
+        assert((tlsBoundTrustedStaticHostOptions.httpsAgent as any).options.maxVersion === 'TLSv1.2', 'TLS-bound trusted static host agent should enforce the requested maximum TLS version');
+        assert((tlsBoundTrustedStaticHostOptions.httpsAgent as any).options.rejectUnauthorized === true, 'TLS-bound trusted static host agent should keep certificate verification enabled');
+        console.log('✅ trusted static host TLS version bounds are explicit and secure by default');
+
         const trustedStaticHostWithRedirects = buildAxiosRequestOptions({ trustedStaticHost: true, maxRedirects: 5 });
         assert(trustedStaticHostWithRedirects.maxRedirects === 0, 'trusted static host requests should force redirects off even when maxRedirects is provided');
         console.log('✅ trusted static host request options force redirects off');

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -27,6 +27,7 @@ const filteringHttpAgents = new Map<string, RequestFilteringHttpAgent>();
 const secureFilteringHttpsAgents = new Map<string, RequestFilteringHttpsAgent>();
 const insecureFilteringHttpsAgents = new Map<string, RequestFilteringHttpsAgent>();
 let insecureTrustedStaticHttpsAgent: https.Agent | null = null;
+let trustedStaticHttpsAgent: https.Agent | null = null;
 const proxyAgents = new Map<string, HttpsProxyAgent<string>>();
 
 function buildFakeIpAgentCacheKey(): string {
@@ -84,6 +85,13 @@ function getInsecureTrustedStaticHttpsAgent(): https.Agent {
         insecureTrustedStaticHttpsAgent = new https.Agent({ rejectUnauthorized: false });
     }
     return insecureTrustedStaticHttpsAgent;
+}
+
+function getTrustedStaticHttpsAgent(): https.Agent {
+    if (!trustedStaticHttpsAgent) {
+        trustedStaticHttpsAgent = new https.Agent({ maxVersion: 'TLSv1.2' });
+    }
+    return trustedStaticHttpsAgent;
 }
 
 export function buildAxiosRequestOptions(options: BuildAxiosRequestOptions = {}): AxiosRequestConfig {
@@ -155,6 +163,9 @@ export function buildAxiosRequestOptions(options: BuildAxiosRequestOptions = {})
         // 该开关只允许用于调用方生成的固定可信 host，并强制禁用重定向，避免扩大 SSRF 面。
         if (allowInsecureTls) {
             requestOptions.httpsAgent = getInsecureTrustedStaticHttpsAgent();
+        } else {
+            // 限制 TLS 1.2 上限，修复部分 CDN（如百度）不支持 TLS 1.3 导致握手失败的问题。
+            requestOptions.httpsAgent = getTrustedStaticHttpsAgent();
         }
     } else {
         requestOptions.httpAgent = getFilteringHttpAgent();

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -19,6 +19,7 @@ type BuildAxiosRequestOptions = {
     params?: unknown;
     responseType?: ResponseType;
     timeout?: number;
+    tlsMaxVersion?: https.AgentOptions['maxVersion'];
     trustedStaticHost?: boolean;
     validateStatus?: AxiosRequestConfig['validateStatus'];
 };
@@ -27,6 +28,7 @@ const filteringHttpAgents = new Map<string, RequestFilteringHttpAgent>();
 const secureFilteringHttpsAgents = new Map<string, RequestFilteringHttpsAgent>();
 const insecureFilteringHttpsAgents = new Map<string, RequestFilteringHttpsAgent>();
 let insecureTrustedStaticHttpsAgent: https.Agent | null = null;
+const versionBoundTrustedStaticHttpsAgents = new Map<string, https.Agent>();
 const proxyAgents = new Map<string, HttpsProxyAgent<string>>();
 
 function buildFakeIpAgentCacheKey(): string {
@@ -86,6 +88,24 @@ function getInsecureTrustedStaticHttpsAgent(): https.Agent {
     return insecureTrustedStaticHttpsAgent;
 }
 
+function getVersionBoundTrustedStaticHttpsAgent(
+    maxVersion: NonNullable<https.AgentOptions['maxVersion']>,
+    allowInsecureTls: boolean
+): https.Agent {
+    const cacheKey = `${maxVersion}::${allowInsecureTls ? 'insecure' : 'secure'}`;
+    const cachedAgent = versionBoundTrustedStaticHttpsAgents.get(cacheKey);
+    if (cachedAgent) {
+        return cachedAgent;
+    }
+
+    const agent = new https.Agent({
+        maxVersion,
+        rejectUnauthorized: !allowInsecureTls
+    });
+    versionBoundTrustedStaticHttpsAgents.set(cacheKey, agent);
+    return agent;
+}
+
 export function buildAxiosRequestOptions(options: BuildAxiosRequestOptions = {}): AxiosRequestConfig {
     const {
         allowInsecureTls = false,
@@ -97,6 +117,7 @@ export function buildAxiosRequestOptions(options: BuildAxiosRequestOptions = {})
         params,
         responseType,
         timeout,
+        tlsMaxVersion,
         trustedStaticHost = false,
         validateStatus
     } = options;
@@ -153,7 +174,9 @@ export function buildAxiosRequestOptions(options: BuildAxiosRequestOptions = {})
         // 修复固定域名 axios 请求在部分网络中失败的问题：搜索/API 域名可能解析到
         // 100.64.0.0/10 这类运营商/代理地址而被 request-filtering-agent 拦截。
         // 该开关只允许用于调用方生成的固定可信 host，并强制禁用重定向，避免扩大 SSRF 面。
-        if (allowInsecureTls) {
+        if (tlsMaxVersion) {
+            requestOptions.httpsAgent = getVersionBoundTrustedStaticHttpsAgent(tlsMaxVersion, allowInsecureTls);
+        } else if (allowInsecureTls) {
             requestOptions.httpsAgent = getInsecureTrustedStaticHttpsAgent();
         }
     } else {


### PR DESCRIPTION
## Problem

Bing routes search traffic differently by region:

- In several non-mainland networks, `cn.bing.com/search` returns a 301 redirect to `www.bing.com`.
- In mainland China, `www.bing.com/search` can return a 302 redirect to `cn.bing.com`.

Search requests use `trustedStaticHost=true`, which intentionally disables automatic redirects. A fixed switch to either hostname therefore repairs one region while breaking another.

Some Baidu CDN paths also reset connections during normal TLS negotiation. Restricting Baidu search requests to TLS 1.2 avoids the incompatible path. Node.js still defaults to TLS 1.2-1.3 negotiation; this is a scoped compatibility measure rather than a change to Node's default behavior.

## Changes

### Bing

- Keep `cn.bing.com` as the initial regional endpoint.
- Expose 3xx responses while keeping Axios automatic redirects disabled.
- Follow at most one regional redirect.
- Allow redirects only over HTTPS, on the default HTTPS port, without credentials, and only between the exact hosts `cn.bing.com` and `www.bing.com`.
- Reject external targets and redirect loops.

### Baidu

- Add an explicit maximum TLS version option for trusted static host requests.
- Apply `TLSv1.2` only to Baidu search requests.
- Keep certificate verification enabled.
- Preserve normal TLS negotiation for every other trusted static host.

### Tests

- Add Bing HTTP tests for direct regional responses, the allowed `cn` to `www` redirect, external redirect rejection, and redirect-loop bounds.
- Verify the Baidu request uses the scoped TLS 1.2 agent.
- Verify generic trusted static host requests remain unchanged unless a TLS maximum is explicitly requested.

## Verification

- `npm run build`
- Bing parser and HTTP request tests
- Baidu and HTTP request option tests
- Live Bing request-mode search: 3 results
- Live Baidu search: 3 results
- Full suite: 36 passed; 2 existing external-network tests were excused by the repository test runner