### PR TITLE
fix: allow Bing engine to follow HTTP redirects (301)

### DIFF
--- a/src/engines/bing/bing.ts
+++ b/src/engines/bing/bing.ts
@@ -118,7 +118,7 @@ function analyzeBlockedPage(html: string): { blocked: boolean; hasResults: boole
 
 function buildBingAxiosRequestOptions(): any {
     return buildSharedAxiosRequestOptions({
-        trustedStaticHost: true,
+        trustedStaticHost: false,
         headers: FALLBACK_HEADERS,
         timeout: config.playwrightNavigationTimeoutMs
     });


### PR DESCRIPTION
## Problem

Bing searches fail with a timeout when `cn.bing.com` returns a 301 redirect to `www.bing.com`. This affects users behind proxies or in regions where `cn.bing.com` redirects.

## Root Cause

In `src/engines/bing/bing.ts`, the `buildBingAxiosRequestOptions()` function sets `trustedStaticHost: true`. In `src/utils/httpRequest.ts`, this forces `maxRedirects: 0`, preventing the HTTP client from following any redirects.

```
// httpRequest.ts:73
const effectiveMaxRedirects = trustedStaticHost ? 0 : maxRedirects;
```

`cn.bing.com/search` returns a `301 → www.bing.com`, but with `maxRedirects: 0` the request fails silently and eventually times out.

## Fix

Changed `trustedStaticHost: true` to `trustedStaticHost: false` in `buildBingAxiosRequestOptions()`, allowing Bing requests to follow redirects (up to 5 hops by default), consistent with the behavior of `fetchWebContent`.

## Testing

Verified locally: after the fix, `open-websearch search "test" --engine bing` returns results successfully instead of timing out.