### PR TITLE
feat(fetch-web): add explicit render modes

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -264,7 +264,7 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 | `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | 默认搜索引擎                               |
 | `USE_PROXY` | `false`                 | `true`, `false` | 启用HTTP代理                             |
 | `PROXY_URL` | `http://127.0.0.1:7890` | 任何有效URL | 代理服务器URL                             |
-| `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | 仅对 `fetchWebContent` 关闭 TLS 证书校验。只建议在目标站点证书链异常时临时使用 |
+| `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | 仅对 `fetchWebContent` 的请求路径关闭 TLS 校验，不影响 Playwright 浏览器导航。只建议在证书链异常时临时使用 |
 | `MODE` | `both`                  | `both`, `http`, `stdio` | 服务器模式：同时支持HTTP+STDIO、仅HTTP或仅STDIO    |
 | `PORT` | `3000`                  | 1-65535 | 服务器端口                                |
 | `ALLOWED_SEARCH_ENGINES` | 空（全部可用） | 逗号分隔的引擎名称 | 限制可使用的搜索引擎，如默认搜索引擎不在范围，则默认第一个为默认搜索引擎 |
@@ -432,7 +432,7 @@ Windows 下的 NPX 配置：
 - 如果 `PROXY_URL` 指向固定上游代理或固定出口，百度、CSDN、掘金、Linux.do、GitHub 这类对地区较敏感的站点表现可能会和之前不同。
 - 如果系统里已经设置了 `HTTP_PROXY` 或 `HTTPS_PROXY`，它们不再覆盖服务器内部请求行为。
 - Windows 上如果站点缺少中间证书，优先建议配置 `NODE_EXTRA_CA_CERTS`。
-- `FETCH_WEB_INSECURE_TLS=true` 只建议作为 `fetchWebContent` 的兜底方案使用，因为它会降低 TLS 校验强度。
+- `FETCH_WEB_INSECURE_TLS=true` 只建议作为 `fetchWebContent` 请求路径的兜底方案；它会降低 TLS 校验强度，且不影响 Playwright 浏览器导航。
 
 **VSCode版(Claude开发扩展):**
 ```json
@@ -698,14 +698,21 @@ use_mcp_tool({
 
 ### fetchWebContent工具使用说明
 
-用于直接抓取公开可访问的 HTTP(S) 链接内容，支持 Markdown 文件（`.md`）和普通网页。
+用于直接抓取公开可访问的 HTTP(S) 链接内容，支持 Markdown 文件（`.md`）、普通网页，以及配置 Playwright 后的 JavaScript 渲染页面。
 
 ```typescript
 {
-  "url": string,         // 公开可访问的 HTTP(S) URL
-  "maxChars": number     // 可选：最大返回字符数（1000-200000，默认30000）
+  "url": string,          // 公开可访问的 HTTP(S) URL
+  "maxChars": number,     // 可选：最大返回字符数（1000-200000，默认30000）
+  "renderMode": string,   // 可选：request、auto（默认）或 browser
+  "readability": boolean, // 可选：对 HTML 使用 Mozilla Readability
+  "includeLinks": boolean // 可选：保留 Readability 输出中的链接
 }
 ```
+
+`request` 不会启动浏览器或使用浏览器 Cookie；`auto` 保持现有的请求优先行为，仅在必要时使用浏览器辅助；`browser` 直接渲染页面，当 Playwright 或浏览器目标不可用时返回明确错误。初始 URL 和最终 URL 仍会经过公网安全校验。
+
+浏览器请求会在继续前重新校验，但该进程不会把 DNS 结果绑定到 Chromium 最终建立的 Socket。远程 Playwright/CDP 端点仍必须使用可信的 DNS 与出站网络策略。
 
 使用示例：
 ```typescript
@@ -714,7 +721,8 @@ use_mcp_tool({
   tool_name: "fetchWebContent",
   arguments: {
     url: "https://raw.githubusercontent.com/Aas-ee/open-webSearch/main/README.md",
-    maxChars: 12000
+    maxChars: 12000,
+    renderMode: "auto"
   }
 })
 ```
@@ -726,6 +734,7 @@ use_mcp_tool({
   "finalUrl": "https://raw.githubusercontent.com/Aas-ee/open-webSearch/main/README.md",
   "contentType": "text/plain; charset=utf-8",
   "title": "",
+  "retrievalMethod": "request",
   "truncated": false,
   "content": "# Open-WebSearch MCP Server ..."
 }

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 | `USE_PROXY` | `false`                 | `true`, `false` | Enable HTTP proxy |
 | `PROXY_URL` | `http://127.0.0.1:7890` | Any valid URL | Proxy server URL |
 | `FAKE_IP_CIDRS` | empty | Comma-separated CIDR list | Treat DNS answers in these CIDRs as synthetic fake-IP results and do not block them as private-network DNS answers. Literal private/local targets and other private-network DNS answers remain blocked |
-| `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | Disable TLS certificate verification for `fetchWebContent` only. Use only when a target site has a broken certificate chain |
+| `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | Disable TLS verification only for the request leg of `fetchWebContent`; it does not affect Playwright browser navigation. Use only for broken certificate chains |
 | `MODE` | `both`                  | `both`, `http`, `stdio` | Server mode: both HTTP+STDIO, HTTP only, or STDIO only |
 | `PORT` | `3000`                  | 1-65535 | Server port |
 | `ALLOWED_SEARCH_ENGINES` | empty (all available) | Comma-separated engine names | Limit which search engines can be used; if the default engine is not in this list, the first allowed engine becomes the default |
@@ -395,7 +395,7 @@ Proxy and TLS notes:
 - If `PROXY_URL` points to a fixed upstream proxy or overseas egress, region-sensitive sites such as Baidu, CSDN, Juejin, Linux.do, or GitHub may behave differently than before.
 - If your host machine already sets `HTTP_PROXY` or `HTTPS_PROXY`, they will no longer override the server's internal request behavior.
 - Prefer configuring `NODE_EXTRA_CA_CERTS` on Windows when a site has a missing intermediate CA.
-- Use `FETCH_WEB_INSECURE_TLS=true` only as a last resort for `fetchWebContent`, since it weakens TLS verification.
+- Use `FETCH_WEB_INSECURE_TLS=true` only as a last resort for the request leg of `fetchWebContent`; it weakens TLS verification and does not affect Playwright browser navigation.
 
 **Local STDIO Configuration for Cherry Studio (Windows):**
 ```json
@@ -604,14 +604,21 @@ Response example:
 
 ### fetchWebContent Tool Usage
 
-Fetch content directly from public HTTP(S) links, including Markdown files (`.md`) and ordinary web pages.
+Fetch content directly from public HTTP(S) links, including Markdown files (`.md`), ordinary pages, and JavaScript-rendered pages when Playwright is configured.
 
 ```typescript
 {
-  "url": string,         // Public HTTP(S) URL
-  "maxChars": number     // Optional: max returned content length (1000-200000, default 30000)
+  "url": string,          // Public HTTP(S) URL
+  "maxChars": number,     // Optional: max returned content length (1000-200000, default 30000)
+  "renderMode": string,   // Optional: request, auto (default), or browser
+  "readability": boolean, // Optional: use Mozilla Readability for HTML
+  "includeLinks": boolean // Optional: preserve links from Readability output
 }
 ```
+
+`request` never starts a browser or uses browser cookies. `auto` preserves the existing request-first behavior and uses browser assistance only when needed. `browser` renders the page directly and returns a clear error if Playwright or its browser target is unavailable. Initial and final URLs remain subject to public-network safety checks.
+
+Browser requests are revalidated before continuation, but this process does not pin DNS answers to Chromium's eventual socket. Remote Playwright/CDP endpoints must therefore enforce their own trusted DNS and egress policy.
 
 Usage example:
 ```typescript
@@ -620,7 +627,8 @@ use_mcp_tool({
   tool_name: "fetchWebContent",
   arguments: {
     url: "https://raw.githubusercontent.com/Aas-ee/open-webSearch/main/README.md",
-    maxChars: 12000
+    maxChars: 12000,
+    renderMode: "auto"
   }
 })
 ```
@@ -632,6 +640,7 @@ Response example:
   "finalUrl": "https://raw.githubusercontent.com/Aas-ee/open-webSearch/main/README.md",
   "contentType": "text/plain; charset=utf-8",
   "title": "",
+  "retrievalMethod": "request",
   "truncated": false,
   "content": "# Open-WebSearch MCP Server ..."
 }

--- a/docs/architecture/cli-json-protocol.md
+++ b/docs/architecture/cli-json-protocol.md
@@ -151,6 +151,8 @@ Notes:
 - `truncated`
 - `content`
 
+The command accepts `--render-mode request|auto|browser`. Omitted mode is `auto`; `request` forbids browser assistance, while `browser` renders directly with Playwright. The selected mode is forwarded unchanged through daemon and direct-runtime execution.
+
 ### Example: article and README fetch commands
 
 This shape applies to:
@@ -234,6 +236,11 @@ CLI search arguments also support:
 - `--search-mode request|auto|playwright`
   - request-level override
   - currently only affects Bing
+
+CLI fetch arguments also support:
+- `--render-mode request|auto|browser`
+  - defaults to `auto`
+  - `browser` uses a longer daemon action timeout because browser navigation may exceed the request-path timeout
 
 ## Serve and status lifecycle
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -170,13 +170,19 @@ Request body:
 ```json
 {
   "url": "https://awiki.ai",
-  "maxChars": 30000
+  "maxChars": 30000,
+  "renderMode": "auto",
+  "readability": false,
+  "includeLinks": false
 }
 ```
 
 Notes:
 - `url` is required
 - `maxChars` is optional, integer `1000-200000`, default `30000`
+- `renderMode` is optional: `request` uses HTTP only, `auto` (default) uses request with browser fallback, and `browser` renders directly with Playwright
+- `readability` and `includeLinks` are optional booleans; `includeLinks` applies to successful Readability output
+- `browser` returns a clear error if Playwright or its configured browser target is unavailable
 - returns the full structured web-fetch payload
 
 Example:
@@ -184,7 +190,7 @@ Example:
 ```bash
 curl --noproxy '*' -X POST http://127.0.0.1:3210/fetch-web \
   -H "Content-Type: application/json" \
-  -d '{"url":"https://awiki.ai","maxChars":3000}'
+  -d '{"url":"https://awiki.ai","maxChars":3000,"renderMode":"browser"}'
 ```
 
 ### `POST /fetch-github-readme`

--- a/skills/open-websearch/SKILL.md
+++ b/skills/open-websearch/SKILL.md
@@ -109,7 +109,7 @@ Apply the decision rules above in order: direct URL fetch first, focused search 
 - If setup requires `npm install`, `npm install -g`, `npx`, or Playwright browser downloads, confirm proxy or mirror expectations before starting the install step in restricted networks.
 - For npm-based installation, prefer npm-specific proxy or registry guidance first when the user's environment depends on it. Typical working paths include `npm --proxy ... --https-proxy ... install ...` for one-shot installs, or `npm config set proxy`, `npm config set https-proxy`, and `npm config set registry` before retrying.
 - Keep npm proxy or registry guidance separate from runtime proxy guidance: npm proxy or mirror settings help package installation, while runtime proxy settings affect `open-websearch serve` and the networked search/fetch actions that follow it.
-- `FETCH_WEB_INSECURE_TLS` only affects `fetchWebContent`, not the search engines.
+- `FETCH_WEB_INSECURE_TLS` only affects the request leg of `fetchWebContent`, not Playwright browser navigation or the search engines.
 - Treat Readability in `fetch-web` as an optional enhancement path. Prefer it when the user wants cleaner extracted content or wants to preserve in-content links for multi-page web research, but do not enable it by default and expect some homepages, navigation-heavy pages, and JS-heavy pages to fall back to the normal extractor.
 - `SEARCH_MODE` currently matters for Bing only.
 - If an error mentions `browserType.launch`, `Executable doesn't exist`, `Playwright client is not available`, or a missing Chromium executable, treat it first as missing browser dependency or browser configuration, not as a generic `open-websearch` core failure.

--- a/skills/open-websearch/references/engine-selection.md
+++ b/skills/open-websearch/references/engine-selection.md
@@ -22,4 +22,4 @@ Engine choice is heuristic, not mandatory. If a preferred engine is unavailable,
 
 - If `bing` returns verification or anti-bot pages, prefer `SEARCH_MODE=auto` or switch engines.
 - If a page fetch fails due to network restrictions, check proxy configuration.
-- If `fetchWebContent` fails on a site with a broken certificate chain, only then consider `FETCH_WEB_INSECURE_TLS=true`.
+- If the request leg of `fetchWebContent` fails on a broken certificate chain, only then consider `FETCH_WEB_INSECURE_TLS=true`; it does not affect Playwright browser navigation.

--- a/skills/open-websearch/references/setup.md
+++ b/skills/open-websearch/references/setup.md
@@ -111,7 +111,7 @@ Use when:
 Stage script:
 1. Collect prerequisites.
    - First distinguish ordinary search/fetch setup from browser-assisted setup.
-   - Do not suggest Playwright installation for ordinary search, `fetchWebContent`, or `fetchGithubReadme` unless browser assistance is actually needed.
+   - Do not suggest Playwright installation for ordinary search, request-mode `fetchWebContent`, or `fetchGithubReadme` unless browser assistance is actually needed. Explicit `renderMode=browser` requires a usable Playwright client and browser target.
    - Confirm whether the user already has a Playwright client, a browser binary, or a remote browser endpoint.
 2. Confirm risky actions.
    - Ask before installing Playwright packages, downloading browser binaries, or changing browser endpoint configuration.

--- a/skills/open-websearch/references/tools.md
+++ b/skills/open-websearch/references/tools.md
@@ -26,10 +26,11 @@ Use for:
 
 Notes:
 - supports Markdown files and normal public pages
-- may fail on pages that require browser cookies or unusual TLS chains
-- some pages may additionally require browser-assisted fallback; if the issue appears to be browser-only content or blocked request-mode access, check whether Playwright/browser support is available before assuming the fetch path itself is broken
+- accepts `renderMode`: `request` is HTTP-only, `auto` (default) is request-first with browser fallback, and `browser` renders directly with Playwright
+- use `browser` when the user explicitly needs client-rendered content; it returns a clear error when Playwright or its browser target is unavailable
+- may fail on pages that require browser cookies, unusual TLS chains, or browser capabilities that are not configured
 - if the user wants cleaner extracted content or wants to preserve in-content links for follow-up multi-page research, prefer the optional Readability path for `fetch-web`; do not assume it is best for every page
-- `FETCH_WEB_INSECURE_TLS` applies only here
+- `FETCH_WEB_INSECURE_TLS` applies only to the request leg; it does not change Playwright browser TLS handling
 - do not jump to TLS or environment explanations for an ordinary fetch failure; first try a better source URL, a more stable result, or a clearer page target
 - do not assume arbitrary homepages or JS-heavy landing pages will yield readable article text; often it is better to search first and then fetch a more specific result page
 

--- a/src/adapters/http/localDaemon.ts
+++ b/src/adapters/http/localDaemon.ts
@@ -4,6 +4,7 @@ import { AppConfig, checkPlaywrightModeConfiguration, getEffectiveSearchMode } f
 import { OpenWebSearchRuntime } from '../../runtime/runtimeTypes.js';
 import { createErrorEnvelope, createSuccessEnvelope } from '../../cli/protocol.js';
 import { normalizeEngineName, resolveRequestedEngines, SupportedSearchEngine } from '../../core/search/searchEngines.js';
+import { validatePublicWebUrl } from '../../core/validation/targetValidation.js';
 import { shutdownLocalPlaywrightBrowserSessions } from '../../utils/playwrightClient.js';
 
 export type LocalDaemonOptions = {
@@ -146,6 +147,16 @@ function parseBooleanFlag(value: unknown, name: string): boolean | undefined {
     return value;
 }
 
+function parseRenderMode(value: unknown): 'request' | 'auto' | 'browser' | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value !== 'request' && value !== 'auto' && value !== 'browser') {
+        throw new Error('renderMode must be one of: request, auto, browser');
+    }
+    return value;
+}
+
 export async function startLocalDaemon(
     runtime: OpenWebSearchRuntime,
     options: LocalDaemonOptions = {}
@@ -248,17 +259,43 @@ export async function startLocalDaemon(
     });
 
     app.post('/fetch-web', async (req, res) => {
+        let input: {
+            url: string;
+            maxChars: number;
+            readability?: boolean;
+            includeLinks?: boolean;
+            renderMode?: 'request' | 'auto' | 'browser';
+        };
         try {
-            const url = parseUrl(req.body?.url);
-            const maxChars = parseMaxChars(req.body?.maxChars);
-            const readability = parseBooleanFlag(req.body?.readability, 'readability');
-            const includeLinks = parseBooleanFlag(req.body?.includeLinks, 'includeLinks');
-            const result = await runtime.services.fetchWeb.execute({ url, maxChars, readability, includeLinks });
-            res.json(createSuccessEnvelope(result));
+            input = {
+                url: parseUrl(req.body?.url),
+                maxChars: parseMaxChars(req.body?.maxChars),
+                readability: parseBooleanFlag(req.body?.readability, 'readability'),
+                includeLinks: parseBooleanFlag(req.body?.includeLinks, 'includeLinks'),
+                renderMode: parseRenderMode(req.body?.renderMode)
+            };
+            if (!validatePublicWebUrl(input.url)) {
+                throw new Error('Invalid public HTTP(S) URL');
+            }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             sendError(res, 400, 'validation_failed', message, {
-                hint: 'Use a public HTTP(S) URL, keep maxChars within the supported range, and pass readability/includeLinks only as booleans.'
+                hint: 'Use a public HTTP(S) URL, keep maxChars within the supported range, pass readability/includeLinks only as booleans, and use renderMode request, auto, or browser.'
+            });
+            return;
+        }
+
+        try {
+            const result = await runtime.services.fetchWeb.execute(input);
+            res.json(createSuccessEnvelope(result));
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            const browserUnavailable = /Playwright client is not available|No Chromium-based browser executable|request interception (?:is unavailable|could not be installed)|connect(?:ion)? (?:failed|refused|timed out)/i.test(message);
+            sendError(res, browserUnavailable ? 503 : 502, browserUnavailable ? 'browser_unavailable' : 'fetch_failed', message, {
+                retryable: !browserUnavailable,
+                hint: browserUnavailable
+                    ? 'Configure a usable Playwright client and browser target, or retry with renderMode request/auto.'
+                    : 'Verify that the target is reachable and retry. Use renderMode request to avoid browser rendering.'
             });
         }
     });

--- a/src/adapters/http/localDaemon.ts
+++ b/src/adapters/http/localDaemon.ts
@@ -5,7 +5,7 @@ import { OpenWebSearchRuntime } from '../../runtime/runtimeTypes.js';
 import { createErrorEnvelope, createSuccessEnvelope } from '../../cli/protocol.js';
 import { normalizeEngineName, resolveRequestedEngines, SupportedSearchEngine } from '../../core/search/searchEngines.js';
 import { validatePublicWebUrl } from '../../core/validation/targetValidation.js';
-import { shutdownLocalPlaywrightBrowserSessions } from '../../utils/playwrightClient.js';
+import { isBrowserUnavailableError, shutdownLocalPlaywrightBrowserSessions } from '../../utils/playwrightClient.js';
 
 export type LocalDaemonOptions = {
     host?: string;
@@ -290,7 +290,8 @@ export async function startLocalDaemon(
             res.json(createSuccessEnvelope(result));
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            const browserUnavailable = /Playwright client is not available|No Chromium-based browser executable|request interception (?:is unavailable|could not be installed)|connect(?:ion)? (?:failed|refused|timed out)/i.test(message);
+            // code 优先（browser_unavailable），消息特征只作未带 code 的历史错误回退。
+            const browserUnavailable = isBrowserUnavailableError(error);
             sendError(res, browserUnavailable ? 503 : 502, browserUnavailable ? 'browser_unavailable' : 'fetch_failed', message, {
                 retryable: !browserUnavailable,
                 hint: browserUnavailable

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -1003,13 +1003,22 @@ export async function runCli(
             return 0;
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
+            // 直连(非 daemon)路径: renderMode=browser 而 Playwright/浏览器不可用时,
+            // 与 daemon 的 /fetch-web 保持一致, 返回 browser_unavailable 而非 validation_failed。
+            const directBrowserUnavailable = !isDaemonRequestError(error)
+                && ((error as { code?: unknown })?.code === 'browser_unavailable'
+                    || /Playwright client is not available|No Chromium-based browser executable|request interception (?:is unavailable|could not be installed)|connect(?:ion)? (?:failed|refused|timed out)/i.test(message));
             if (parsed.json) {
                 io.stdout(JSON.stringify(createErrorEnvelope(
-                    isDaemonRequestError(error) ? getDaemonCliErrorCode(error) : 'validation_failed',
+                    isDaemonRequestError(error)
+                        ? getDaemonCliErrorCode(error)
+                        : (directBrowserUnavailable ? 'browser_unavailable' : 'validation_failed'),
                     message,
                     { hint: isDaemonRequestError(error)
                         ? getDaemonCliErrorHint(error)
-                        : 'Use a public HTTP(S) URL, keep maxChars within the supported range, and use renderMode request, auto, or browser.' }
+                        : (directBrowserUnavailable
+                            ? 'Configure a usable Playwright client and browser target, or retry with renderMode request/auto.'
+                            : 'Use a public HTTP(S) URL, keep maxChars within the supported range, and use renderMode request, auto, or browser.') }
                 ), null, 2));
             } else {
                 io.stderr(`${getDaemonCliErrorLabel(error, 'Fetch failed')}: ${message}`);

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -53,8 +53,8 @@ function formatCliHelp(): string {
         'One-shot action commands:',
         '  open-websearch search <query> [--limit N] [--engine NAME] [--engines a,b] [--search-mode MODE] [--daemon-url URL] [--spawn] [--json]',
         '    Search the web. `--search-mode` is request|auto|playwright and currently only affects Bing.',
-        '  open-websearch fetch-web <url> [--max-chars N] [--readability] [--include-links] [--daemon-url URL] [--spawn] [--json]',
-        '    Fetch readable page content. `--readability` enables Mozilla Readability extraction; `--include-links` returns preserved article links.',
+        '  open-websearch fetch-web <url> [--max-chars N] [--render-mode MODE] [--readability] [--include-links] [--daemon-url URL] [--spawn] [--json]',
+        '    Fetch readable page content. `--render-mode` is request|auto|browser; browser renders directly with Playwright. `--readability` enables Mozilla Readability extraction; `--include-links` preserves article links.',
         '  open-websearch fetch-github-readme <url> [--daemon-url URL] [--spawn] [--json]',
         '  open-websearch fetch-csdn <url> [--daemon-url URL] [--spawn] [--json]',
         '  open-websearch fetch-juejin <url> [--daemon-url URL] [--spawn] [--json]',
@@ -94,6 +94,7 @@ export type ParsedFetchWebArgs = {
     maxChars: number;
     readability: boolean;
     includeLinks: boolean;
+    renderMode?: 'request' | 'auto' | 'browser';
     json: boolean;
 };
 
@@ -141,7 +142,14 @@ function parsePositiveTimeout(value: string | undefined, fallback: number): numb
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function getDaemonActionTimeoutMs(transport: DaemonTransportArgs): number {
+function getDaemonActionTimeoutMs(
+    transport: DaemonTransportArgs,
+    path: string,
+    body: Record<string, unknown>
+): number {
+    if (path === '/fetch-web') {
+        return parsePositiveTimeout(process.env.OPEN_WEBSEARCH_DAEMON_ACTION_TIMEOUT_MS, 60000);
+    }
     if (transport.daemonUrlExplicit) {
         return parsePositiveTimeout(process.env.OPEN_WEBSEARCH_DAEMON_ACTION_TIMEOUT_MS, 15000);
     }
@@ -286,6 +294,7 @@ export function parseFetchWebArgs(argv: string[]): ParsedFetchWebArgs {
     let maxChars = 30000;
     let readability = false;
     let includeLinks = false;
+    let renderMode: ParsedFetchWebArgs['renderMode'];
     let json = false;
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -316,6 +325,19 @@ export function parseFetchWebArgs(argv: string[]): ParsedFetchWebArgs {
             continue;
         }
 
+        if (arg === '--render-mode') {
+            const next = argv[index + 1];
+            if (!next || isFlag(next)) {
+                throw new Error('Missing value for --render-mode');
+            }
+            if (next !== 'request' && next !== 'auto' && next !== 'browser') {
+                throw new Error('renderMode must be one of: request, auto, browser');
+            }
+            renderMode = next;
+            index += 1;
+            continue;
+        }
+
         if (isFlag(arg)) {
             throw new Error(`Unknown argument: ${arg}`);
         }
@@ -336,6 +358,7 @@ export function parseFetchWebArgs(argv: string[]): ParsedFetchWebArgs {
         maxChars,
         readability,
         includeLinks,
+        renderMode,
         json
     };
 }
@@ -631,7 +654,7 @@ async function requestDaemonEnvelope<T>(
     path: string,
     body: Record<string, unknown>
 ): Promise<CliEnvelope<T>> {
-    const timeoutMs = getDaemonActionTimeoutMs(transport);
+    const timeoutMs = getDaemonActionTimeoutMs(transport, path, body);
 
     try {
         return await requestJsonWithTimeout<CliEnvelope<T>>(new URL(path, transport.daemonUrl).toString(), {
@@ -671,7 +694,7 @@ async function tryDaemonRequest<T>(
 
         if (
             !transport.daemonUrlExplicit &&
-            (error instanceof DaemonUnavailableError || error instanceof DaemonRequestTimeoutError || error instanceof DaemonRequestFailedError)
+            error instanceof DaemonUnavailableError
         ) {
             return null;
         }
@@ -928,11 +951,11 @@ export async function runCli(
                 io.stdout(JSON.stringify(createErrorEnvelope(
                     'invalid_arguments',
                     message,
-                    { hint: 'Use `open-websearch fetch-web <url> [--max-chars N] [--json]`.' }
+                    { hint: 'Use `open-websearch fetch-web <url> [--max-chars N] [--render-mode request|auto|browser] [--json]`.' }
                 ), null, 2));
             } else {
                 io.stderr(message);
-                io.stderr('Usage: open-websearch fetch-web <url> [--max-chars N] [--readability] [--include-links] [--json]');
+                io.stderr('Usage: open-websearch fetch-web <url> [--max-chars N] [--render-mode request|auto|browser] [--readability] [--include-links] [--json]');
             }
             return 1;
         }
@@ -945,7 +968,8 @@ export async function runCli(
                     url: parsed.url,
                     maxChars: parsed.maxChars,
                     readability: parsed.readability,
-                    includeLinks: parsed.includeLinks
+                    includeLinks: parsed.includeLinks,
+                    renderMode: parsed.renderMode
                 },
                 options
             );
@@ -967,7 +991,8 @@ export async function runCli(
                 url: parsed.url,
                 maxChars: parsed.maxChars,
                 readability: parsed.readability,
-                includeLinks: parsed.includeLinks
+                includeLinks: parsed.includeLinks,
+                renderMode: parsed.renderMode
             });
 
             if (parsed.json) {
@@ -984,7 +1009,7 @@ export async function runCli(
                     message,
                     { hint: isDaemonRequestError(error)
                         ? getDaemonCliErrorHint(error)
-                        : 'Use a public HTTP(S) URL and keep maxChars within the supported range.' }
+                        : 'Use a public HTTP(S) URL, keep maxChars within the supported range, and use renderMode request, auto, or browser.' }
                 ), null, 2));
             } else {
                 io.stderr(`${getDaemonCliErrorLabel(error, 'Fetch failed')}: ${message}`);

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -7,6 +7,7 @@ import https from 'node:https';
 import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { AppConfig } from '../config.js';
+import { isBrowserUnavailableError } from '../utils/playwrightClient.js';
 
 export type CliIo = {
     stdout: (text: string) => void;
@@ -733,7 +734,7 @@ function getDaemonCliErrorCode(error: unknown): string {
     }
 
     // 强制 Playwright 而配置无效：直接暴露配置错误，不再归入通用的 engine_error。
-    if ((error as { code?: unknown })?.code === 'browser_unavailable') {
+    if (isBrowserUnavailableError(error)) {
         return 'browser_unavailable';
     }
 
@@ -753,7 +754,7 @@ function getDaemonCliErrorHint(error: unknown): string {
         return 'The daemon accepted the request but did not complete it cleanly. Inspect daemon logs or retry without --daemon-url to use direct execution.';
     }
 
-    if ((error as { code?: unknown })?.code === 'browser_unavailable') {
+    if (isBrowserUnavailableError(error)) {
         return 'Fix the Playwright configuration (install a client package, set PLAYWRIGHT_MODULE_PATH or a remote endpoint, provide a browser binary), or retry with --search-mode request.';
     }
 
@@ -1006,8 +1007,7 @@ export async function runCli(
             // 直连(非 daemon)路径: renderMode=browser 而 Playwright/浏览器不可用时,
             // 与 daemon 的 /fetch-web 保持一致, 返回 browser_unavailable 而非 validation_failed。
             const directBrowserUnavailable = !isDaemonRequestError(error)
-                && ((error as { code?: unknown })?.code === 'browser_unavailable'
-                    || /Playwright client is not available|No Chromium-based browser executable|request interception (?:is unavailable|could not be installed)|connect(?:ion)? (?:failed|refused|timed out)/i.test(message));
+                && isBrowserUnavailableError(error);
             if (parsed.json) {
                 io.stdout(JSON.stringify(createErrorEnvelope(
                     isDaemonRequestError(error)

--- a/src/core/fetch/fetchServices.ts
+++ b/src/core/fetch/fetchServices.ts
@@ -42,18 +42,20 @@ export function createWebFetchService(fetcher: WebFetcher) {
             url,
             maxChars,
             readability,
-            includeLinks
+            includeLinks,
+            renderMode
         }: {
             url: string;
             maxChars: number;
             readability?: boolean;
             includeLinks?: boolean;
+            renderMode?: FetchWebContentOptions['renderMode'];
         }): Promise<FetchWebContentResult> {
             if (!validatePublicWebUrl(url)) {
                 throw new Error('Invalid public HTTP(S) URL');
             }
 
-            return fetcher(url, maxChars, { readability, includeLinks });
+            return fetcher(url, maxChars, { readability, includeLinks, renderMode });
         }
     };
 }

--- a/src/engines/web/fetchWebContent.ts
+++ b/src/engines/web/fetchWebContent.ts
@@ -6,7 +6,8 @@ import { assertPublicHttpUrl, assertPublicHttpUrlResolved } from '../../utils/ur
 import {
     fetchPageHtmlWithBrowser,
     getBrowserCookieHeader,
-    looksLikeBotChallengePage
+    looksLikeBotChallengePage,
+    MAX_BROWSER_HTML_BYTES
 } from '../../utils/browserCookies.js';
 
 export interface FetchWebContentResult {
@@ -33,7 +34,10 @@ export type ExtractedLink = {
 export type FetchWebContentOptions = {
     readability?: boolean;
     includeLinks?: boolean;
+    renderMode?: FetchWebRenderMode;
 };
+
+export type FetchWebRenderMode = 'request' | 'auto' | 'browser';
 
 const DEFAULT_TIMEOUT_MS = 20000;
 const DEFAULT_MAX_CHARS = 30000;
@@ -105,6 +109,7 @@ function isMarkdownContentType(contentType: string): boolean {
 }
 
 let browserHtmlFetcher: typeof fetchPageHtmlWithBrowser = fetchPageHtmlWithBrowser;
+let browserCookieHeaderFetcher: typeof getBrowserCookieHeader = getBrowserCookieHeader;
 let readabilityParser: (html: string, finalUrl: string) => Promise<ReadabilityArticle | null> = async (html, finalUrl) => {
     try {
         const moduleName = '@mozilla/readability';
@@ -248,17 +253,26 @@ function shouldTryBrowserHtmlFallback(contentType: string, raw: string, extracti
     return false;
 }
 
-async function fetchHtmlViaBrowser(url: string): Promise<{ contentType: string; finalUrl: string; raw: string; title: string } | undefined> {
-    try {
-        const browserPage = await browserHtmlFetcher(url);
-        assertPublicHttpUrl(browserPage.finalUrl, 'Final URL');
+async function fetchHtmlViaBrowser(url: string): Promise<{ contentType: string; finalUrl: string; raw: string; title: string }> {
+    const browserPage = await browserHtmlFetcher(url);
+    await assertPublicHttpUrlResolved(browserPage.finalUrl, 'Final URL');
 
-        return {
-            contentType: 'text/html; charset=utf-8',
-            finalUrl: browserPage.finalUrl,
-            raw: browserPage.html,
-            title: browserPage.title
-        };
+    const htmlBytes = Buffer.byteLength(browserPage.html, 'utf8');
+    if (htmlBytes > MAX_BROWSER_HTML_BYTES) {
+        throw new Error(`Response body too large (${htmlBytes} bytes). Max allowed is ${MAX_BROWSER_HTML_BYTES} bytes`);
+    }
+
+    return {
+        contentType: 'text/html; charset=utf-8',
+        finalUrl: browserPage.finalUrl,
+        raw: browserPage.html,
+        title: browserPage.title
+    };
+}
+
+async function tryFetchHtmlViaBrowser(url: string): Promise<{ contentType: string; finalUrl: string; raw: string; title: string } | undefined> {
+    try {
+        return await fetchHtmlViaBrowser(url);
     } catch {
         return undefined;
     }
@@ -266,6 +280,10 @@ async function fetchHtmlViaBrowser(url: string): Promise<{ contentType: string; 
 
 export function __setBrowserHtmlFetcherForTests(fetcher?: typeof fetchPageHtmlWithBrowser): void {
     browserHtmlFetcher = fetcher || fetchPageHtmlWithBrowser;
+}
+
+export function __setBrowserCookieHeaderFetcherForTests(fetcher?: typeof getBrowserCookieHeader): void {
+    browserCookieHeaderFetcher = fetcher || getBrowserCookieHeader;
 }
 
 export function __setReadabilityParserForTests(parser?: (html: string, finalUrl: string) => Promise<ReadabilityArticle | null>): void {
@@ -287,7 +305,7 @@ export function __setReadabilityParserForTests(parser?: (html: string, finalUrl:
 async function tryRequestWithBrowserCookies(url: string): Promise<{ response?: any; usedBrowserCookies: boolean }> {
     let cookieHeader: string | undefined;
     try {
-        cookieHeader = await getBrowserCookieHeader(url);
+        cookieHeader = await browserCookieHeaderFetcher(url);
     } catch {
         return { response: undefined, usedBrowserCookies: false };
     }
@@ -316,87 +334,105 @@ export async function fetchWebContent(
 ): Promise<FetchWebContentResult> {
     const parsedUrl = new URL(url);
     await assertPublicHttpUrlResolved(parsedUrl, 'Request URL');
-
-    const requestOptions = buildRequestOptions();
-
-    // Pre-flight check to avoid downloading oversized payloads when Content-Length is present.
-    try {
-        const headResponse = await requestWithSafeRedirects('HEAD', parsedUrl.toString(), {
-            ...requestOptions,
-            responseType: 'json',
-            validateStatus: (status: number) => status >= 200 && status < 400
-        }, 'Request URL');
-        const headLength = Number(headResponse.headers['content-length']);
-        if (Number.isFinite(headLength) && headLength > MAX_DOWNLOAD_BYTES) {
-            const tooLargeError = new Error(`Response body too large (${headLength} bytes). Max allowed is ${MAX_DOWNLOAD_BYTES} bytes`);
-            (tooLargeError as any).code = 'ERR_RESPONSE_TOO_LARGE';
-            throw tooLargeError;
-        }
-    } catch (error: any) {
-        if (error?.code === 'ERR_RESPONSE_TOO_LARGE') {
-            throw error;
-        }
-        const status = error?.response?.status;
-        // Some servers don't support HEAD correctly; continue and rely on GET download limits.
-        if (status !== undefined && ![400, 403, 404, 405, 406, 501].includes(status)) {
-            throw error;
-        }
+    const renderMode = options.renderMode ?? 'auto';
+    if (!['request', 'auto', 'browser'].includes(renderMode)) {
+        throw new Error('renderMode must be one of: request, auto, browser');
     }
 
-    let response: any;
-    let usedBrowserCookies = false;
+    let contentType = '';
+    let finalUrl = parsedUrl.toString();
+    let raw = '';
+    let browserTitle = '';
     let retrievalMethod: FetchWebContentResult['retrievalMethod'] = 'request';
 
-    try {
-        response = await requestWithSafeRedirects('GET', parsedUrl.toString(), requestOptions, 'Request URL');
-    } catch (error: any) {
-        const status = error?.response?.status;
-        if (![401, 403, 429].includes(status)) {
-            throw error;
+    if (renderMode === 'browser') {
+        const browserResult = await fetchHtmlViaBrowser(parsedUrl.toString());
+        contentType = browserResult.contentType;
+        finalUrl = browserResult.finalUrl;
+        raw = browserResult.raw;
+        browserTitle = browserResult.title;
+        retrievalMethod = 'browser-html';
+    } else {
+        const requestOptions = buildRequestOptions();
+
+        // Pre-flight check to avoid downloading oversized payloads when Content-Length is present.
+        try {
+            const headResponse = await requestWithSafeRedirects('HEAD', parsedUrl.toString(), {
+                ...requestOptions,
+                responseType: 'json',
+                validateStatus: (status: number) => status >= 200 && status < 400
+            }, 'Request URL');
+            const headLength = Number(headResponse.headers['content-length']);
+            if (Number.isFinite(headLength) && headLength > MAX_DOWNLOAD_BYTES) {
+                const tooLargeError = new Error(`Response body too large (${headLength} bytes). Max allowed is ${MAX_DOWNLOAD_BYTES} bytes`);
+                (tooLargeError as any).code = 'ERR_RESPONSE_TOO_LARGE';
+                throw tooLargeError;
+            }
+        } catch (error: any) {
+            if (error?.code === 'ERR_RESPONSE_TOO_LARGE') {
+                throw error;
+            }
+            const status = error?.response?.status;
+            // Some servers don't support HEAD correctly; continue and rely on GET download limits.
+            if (status !== undefined && ![400, 403, 404, 405, 406, 501].includes(status)) {
+                throw error;
+            }
         }
 
-        const cookieRetry = await tryRequestWithBrowserCookies(parsedUrl.toString());
-        if (cookieRetry.response) {
-            response = cookieRetry.response;
-            usedBrowserCookies = cookieRetry.usedBrowserCookies;
-            retrievalMethod = 'request-with-browser-cookies';
-        } else {
-            response = {
-                headers: { 'content-type': 'text/html; charset=utf-8' },
-                data: '',
-                request: { res: { responseUrl: parsedUrl.toString() } }
-            };
+        let response: any;
+        let usedBrowserCookies = false;
+
+        try {
+            response = await requestWithSafeRedirects('GET', parsedUrl.toString(), requestOptions, 'Request URL');
+        } catch (error: any) {
+            const status = error?.response?.status;
+            if (renderMode === 'request' || ![401, 403, 429].includes(status)) {
+                throw error;
+            }
+
+            const cookieRetry = await tryRequestWithBrowserCookies(parsedUrl.toString());
+            if (cookieRetry.response) {
+                response = cookieRetry.response;
+                usedBrowserCookies = cookieRetry.usedBrowserCookies;
+                retrievalMethod = 'request-with-browser-cookies';
+            } else {
+                response = {
+                    headers: { 'content-type': 'text/html; charset=utf-8' },
+                    data: '',
+                    request: { res: { responseUrl: parsedUrl.toString() } }
+                };
+            }
+        }
+
+        contentType = String(response.headers['content-type'] || '').toLowerCase();
+        finalUrl = response.request?.res?.responseUrl || parsedUrl.toString();
+        assertPublicHttpUrl(finalUrl, 'Final URL');
+        raw = typeof response.data === 'string'
+            ? response.data
+            : JSON.stringify(response.data, null, 2);
+
+        if (renderMode === 'auto' && !usedBrowserCookies && looksLikeBotChallengePage(raw)) {
+            const cookieRetry = await tryRequestWithBrowserCookies(parsedUrl.toString());
+            if (cookieRetry.response) {
+                response = cookieRetry.response;
+                usedBrowserCookies = true;
+                retrievalMethod = 'request-with-browser-cookies';
+                contentType = String(response.headers['content-type'] || '').toLowerCase();
+                finalUrl = response.request?.res?.responseUrl || parsedUrl.toString();
+                assertPublicHttpUrl(finalUrl, 'Final URL');
+                raw = typeof response.data === 'string'
+                    ? response.data
+                    : JSON.stringify(response.data, null, 2);
+            }
+        }
+
+        const contentLength = Number(response.headers['content-length']);
+        if (Number.isFinite(contentLength) && contentLength > MAX_DOWNLOAD_BYTES) {
+            throw new Error(`Response body too large (${contentLength} bytes). Max allowed is ${MAX_DOWNLOAD_BYTES} bytes`);
         }
     }
 
-    let contentType = String(response.headers['content-type'] || '').toLowerCase();
-    let finalUrl = response.request?.res?.responseUrl || parsedUrl.toString();
-    assertPublicHttpUrl(finalUrl, 'Final URL');
-    let raw = typeof response.data === 'string'
-        ? response.data
-        : JSON.stringify(response.data, null, 2);
-
-    if (!usedBrowserCookies && looksLikeBotChallengePage(raw)) {
-        const cookieRetry = await tryRequestWithBrowserCookies(parsedUrl.toString());
-        if (cookieRetry.response) {
-            response = cookieRetry.response;
-            usedBrowserCookies = true;
-            retrievalMethod = 'request-with-browser-cookies';
-            contentType = String(response.headers['content-type'] || '').toLowerCase();
-            finalUrl = response.request?.res?.responseUrl || parsedUrl.toString();
-            assertPublicHttpUrl(finalUrl, 'Final URL');
-            raw = typeof response.data === 'string'
-                ? response.data
-                : JSON.stringify(response.data, null, 2);
-        }
-    }
-
-    const contentLength = Number(response.headers['content-length']);
-    if (Number.isFinite(contentLength) && contentLength > MAX_DOWNLOAD_BYTES) {
-        throw new Error(`Response body too large (${contentLength} bytes). Max allowed is ${MAX_DOWNLOAD_BYTES} bytes`);
-    }
-
-    let title = '';
+    let title = browserTitle;
     let extractedContent = '';
     let htmlExtraction: HtmlExtractionResult | undefined;
     let readabilityApplied = false;
@@ -409,11 +445,11 @@ export async function fetchWebContent(
     const finalParsedUrl = new URL(finalUrl);
 
     // Keep raw markdown behavior for the resolved final path.
-    if (isMarkdownPath(finalParsedUrl)) {
+    if (retrievalMethod !== 'browser-html' && isMarkdownPath(finalParsedUrl)) {
         extractedContent = normalizeText(raw);
     } else if (contentType.includes('text/html') || looksLikeHtml(raw)) {
         htmlExtraction = extractMainTextFromHtml(raw);
-        title = htmlExtraction.title;
+        title = htmlExtraction.title || title;
         extractedContent = htmlExtraction.text;
     } else if (isMarkdownContentType(contentType)) {
         extractedContent = normalizeText(raw);
@@ -421,8 +457,8 @@ export async function fetchWebContent(
         extractedContent = normalizeText(raw);
     }
 
-    if (shouldTryBrowserHtmlFallback(contentType, raw, htmlExtraction)) {
-        const browserResult = await fetchHtmlViaBrowser(parsedUrl.toString());
+    if (renderMode === 'auto' && shouldTryBrowserHtmlFallback(contentType, raw, htmlExtraction)) {
+        const browserResult = await tryFetchHtmlViaBrowser(parsedUrl.toString());
         if (browserResult) {
             contentType = browserResult.contentType;
             finalUrl = browserResult.finalUrl;

--- a/src/runtime/runtimeTypes.ts
+++ b/src/runtime/runtimeTypes.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from '../config.js';
 import { SearchExecutionInput, SearchExecutionResult } from '../core/search/searchService.js';
-import { FetchWebContentResult } from '../engines/web/fetchWebContent.js';
+import { FetchWebContentOptions, FetchWebContentResult } from '../engines/web/fetchWebContent.js';
 
 export type SearchService = {
     execute(input: SearchExecutionInput): Promise<SearchExecutionResult>;
@@ -20,6 +20,7 @@ export type FetchWebService = {
         maxChars: number;
         readability?: boolean;
         includeLinks?: boolean;
+        renderMode?: FetchWebContentOptions['renderMode'];
     }): Promise<FetchWebContentResult>;
 };
 

--- a/src/test/test-browser-path-guard.ts
+++ b/src/test/test-browser-path-guard.ts
@@ -1,5 +1,7 @@
 import {
     __getBrowserSubresourceClassificationForTests,
+    __createCookieCollectionPageForTests,
+    __installNavigationGuardForTests,
     __resetBrowserSubresourceCacheForTests,
     classifyBrowserSubresourceUrl,
     fetchPageHtmlWithBrowser,
@@ -39,6 +41,47 @@ async function assertRejects(
 
 async function run(): Promise<void> {
     installTestDnsLookup();
+
+    await assertRejects(
+        () => __installNavigationGuardForTests({}),
+        /request interception is unavailable/,
+        'browser page without route interception'
+    );
+    console.log('✅ browser navigation fails closed without route interception');
+
+    await assertRejects(
+        () => __installNavigationGuardForTests({
+            route: async () => {
+                throw new Error('route unsupported');
+            }
+        }),
+        /could not be installed/,
+        'browser page whose route installation fails'
+    );
+    console.log('✅ browser navigation fails closed when route installation fails');
+
+    let abandonedContextClosed = 0;
+    const fallbackPage = { close: async () => undefined };
+    const fallbackContext = {
+        newPage: async () => fallbackPage,
+        clearCookies: async () => undefined
+    };
+    const pageHandle = await __createCookieCollectionPageForTests({
+        newContext: async () => ({
+            newPage: async () => {
+                throw new Error('new page failed');
+            },
+            close: async () => {
+                abandonedContextClosed += 1;
+            }
+        }),
+        contexts: () => [fallbackContext]
+    });
+    if (abandonedContextClosed !== 1 || pageHandle.page !== fallbackPage) {
+        throw new Error('failed dedicated browser context should close before default-context fallback');
+    }
+    await pageHandle.close();
+    console.log('✅ failed dedicated browser context closes before fallback');
 
     // getBrowserCookieHeader must reject before loading Playwright.
     await assertRejects(
@@ -135,15 +178,41 @@ async function run(): Promise<void> {
     );
     console.log('✅ subresource guard rejects repeated DNS-resolved private (cache hit)');
 
-    await classifyBrowserSubresourceUrl('http://public-dns.example/cdn/asset.css');
-    if (__getBrowserSubresourceClassificationForTests('public-dns.example') !== true) {
-        throw new Error('expected cached positive classification for public-dns.example');
+    // Rebind defense: a host that resolves public then private across requests
+    // must be blocked on the second request (public allows are never cached).
+    let rebindLookups = 0;
+    __setDnsLookupForTests(async (hostname) => {
+        if (hostname !== 'rebind.example') {
+            throw new Error(`unexpected hostname: ${hostname}`);
+        }
+        rebindLookups += 1;
+        return [{ address: rebindLookups === 1 ? '93.184.216.34' : '127.0.0.1' }];
+    });
+    await classifyBrowserSubresourceUrl('https://rebind.example/first.js');
+    await assertRejects(
+        () => classifyBrowserSubresourceUrl('https://rebind.example/second.js'),
+        /resolves to private IP/,
+        'subresource host that resolves public then private across requests'
+    );
+    if (rebindLookups !== 2) {
+        throw new Error(`expected two DNS lookups for rebinding defense, got ${rebindLookups}`);
     }
-    console.log('✅ subresource guard allows public DNS-resolved host and caches positive classification');
+    console.log('✅ subresource guard revalidates public hosts on subsequent requests');
 
-    // Second call must succeed and stay cached.
+    // 重新装回确定性映射，供下面的 public-host 断言使用。
+    installTestDnsLookup();
+
+    // Public hosts are never cached: each request re-resolves so a later
+    // private resolution cannot be masked by an earlier allow decision.
+    await classifyBrowserSubresourceUrl('http://public-dns.example/cdn/asset.css');
+    if (__getBrowserSubresourceClassificationForTests('public-dns.example') !== undefined) {
+        throw new Error('public subresource classifications must not be cached');
+    }
+    console.log('✅ subresource guard allows public DNS-resolved host without caching an allow decision');
+
+    // Second call must resolve again rather than trusting an earlier allow.
     await classifyBrowserSubresourceUrl('http://public-dns.example/cdn/other.js');
-    console.log('✅ subresource guard allows repeated public host (cache hit)');
+    console.log('✅ subresource guard revalidates repeated public hosts');
 
     // 恢复默认 DNS 解析，避免影响同进程内后续测试。
     __setDnsLookupForTests();

--- a/src/test/test-cli-search.ts
+++ b/src/test/test-cli-search.ts
@@ -72,7 +72,7 @@ function createStubRuntime(configOverrides: Partial<AppConfig> = {}) {
                 title: 'Example',
                 retrievalMethod: 'request' as const,
                 truncated: false,
-                content: `ok:${maxChars}:${options?.readability ? 'readability' : 'plain'}`,
+                content: `ok:${maxChars}:${options?.readability ? 'readability' : 'plain'}:${options?.renderMode ?? 'auto'}`,
                 readabilityApplied: options?.readability ?? false,
                 links: options?.includeLinks ? [{ text: 'Doc', href: 'https://example.com/doc' }] : undefined
             }),
@@ -142,13 +142,24 @@ function testParseFetchArgs(): void {
         '5000',
         '--readability',
         '--include-links',
+        '--render-mode',
+        'browser',
         '--json'
     ]);
     assertEqual(parsedWeb.url, 'https://example.com', 'parsed fetch-web url');
     assertEqual(parsedWeb.maxChars, 5000, 'parsed fetch-web maxChars');
     assertEqual(parsedWeb.readability, true, 'parsed fetch-web readability');
     assertEqual(parsedWeb.includeLinks, true, 'parsed fetch-web include-links');
+    assertEqual(parsedWeb.renderMode, 'browser', 'parsed fetch-web render mode');
     assertEqual(parsedWeb.json, true, 'parsed fetch-web json flag');
+
+    let invalidRenderModeRejected = false;
+    try {
+        parseFetchWebArgs(['https://example.com', '--render-mode', 'invalid']);
+    } catch {
+        invalidRenderModeRejected = true;
+    }
+    assert(invalidRenderModeRejected, 'invalid fetch-web render mode should be rejected');
 
     const parsedGithub = parseFetchGithubArgs([
         'https://github.com/Aas-ee/open-webSearch',
@@ -396,7 +407,7 @@ async function testRunCliFetchWebJsonSuccess(): Promise<void> {
     assertEqual(payload.status, 'ok', 'CLI fetch-web json status');
     assertEqual(payload.data.url, 'https://example.com', 'CLI fetch-web json url');
     assertEqual(payload.data.title, 'Example', 'CLI fetch-web json title');
-    assertEqual(payload.data.content, 'ok:4321:plain', 'CLI fetch-web json content');
+    assertEqual(payload.data.content, 'ok:4321:plain:auto', 'CLI fetch-web json content');
 
     console.log('✅ CLI runCli fetch-web json success');
 }
@@ -406,7 +417,7 @@ async function testRunCliFetchWebReadabilityJsonSuccess(): Promise<void> {
     const stdout: string[] = [];
     const stderr: string[] = [];
     const exitCode = await runCli(
-        ['fetch-web', 'https://example.com', '--max-chars', '4321', '--readability', '--include-links', '--json'],
+        ['fetch-web', 'https://example.com', '--max-chars', '4321', '--render-mode', 'browser', '--readability', '--include-links', '--json'],
         runtime,
         {
             stdout: (text) => stdout.push(text),
@@ -421,7 +432,7 @@ async function testRunCliFetchWebReadabilityJsonSuccess(): Promise<void> {
         data: { content: string; readabilityApplied?: boolean; links?: Array<{ href: string }> };
     };
     assertEqual(payload.status, 'ok', 'CLI fetch-web readability json status');
-    assertEqual(payload.data.content, 'ok:4321:readability', 'CLI fetch-web readability json content');
+    assertEqual(payload.data.content, 'ok:4321:readability:browser', 'CLI fetch-web readability json content');
     assertEqual(payload.data.readabilityApplied, true, 'CLI fetch-web readability flag');
     assertEqual(payload.data.links?.[0]?.href, 'https://example.com/doc', 'CLI fetch-web readability links');
 
@@ -611,7 +622,24 @@ async function testRunCliFetchLinuxDoValidationFailure(): Promise<void> {
 }
 
 async function testRunCliPrefersDaemonWhenAvailable(): Promise<void> {
-    const localRuntime = createStubRuntime();
+    let localFetchCalls = 0;
+    const localRuntime = createOpenWebSearchRuntime({
+        config: createTestConfig(),
+        dependencies: {
+            fetchWebContent: async (url, maxChars) => {
+                localFetchCalls += 1;
+                return {
+                    url,
+                    finalUrl: url,
+                    contentType: 'text/plain',
+                    title: 'Local',
+                    retrievalMethod: 'request' as const,
+                    truncated: false,
+                    content: `local:${maxChars}`
+                };
+            }
+        }
+    });
     const daemonRuntime = createOpenWebSearchRuntime({
         config: createTestConfig(),
         dependencies: {
@@ -625,14 +653,14 @@ async function testRunCliPrefersDaemonWhenAvailable(): Promise<void> {
                 }]
             },
             fetchGithubReadme: async () => '# README',
-            fetchWebContent: async (url, maxChars) => ({
+            fetchWebContent: async (url, maxChars, options) => ({
                 url,
                 finalUrl: url,
                 contentType: 'text/plain',
                 title: 'Example',
                 retrievalMethod: 'request' as const,
                 truncated: false,
-                content: `daemon:${maxChars}`
+                content: `daemon:${maxChars}:${options?.renderMode ?? 'auto'}`
             }),
             fetchCsdnArticle: async () => ({ content: 'daemon-csdn' }),
             fetchJuejinArticle: async () => ({ content: 'daemon-juejin' }),
@@ -662,6 +690,17 @@ async function testRunCliPrefersDaemonWhenAvailable(): Promise<void> {
             };
             assertEqual(payload.status, 'ok', 'CLI daemon preferred payload status');
             assertEqual(payload.data.results[0].description, 'served-by-daemon', 'CLI should prefer daemon result');
+
+            const fetchStdout: string[] = [];
+            const fetchExitCode = await runCli(
+                ['fetch-web', 'https://example.com', '--render-mode', 'browser', '--json'],
+                localRuntime,
+                { stdout: (text) => fetchStdout.push(text), stderr: () => undefined }
+            );
+            const fetchPayload = JSON.parse(fetchStdout[0]) as { status: string; data: { content: string } };
+            assertEqual(fetchExitCode, 0, 'CLI daemon fetch-web exit code');
+            assertEqual(fetchPayload.data.content, 'daemon:30000:browser', 'CLI should forward renderMode through daemon');
+            assertEqual(localFetchCalls, 0, 'CLI should not execute fetch-web locally when daemon succeeds');
         });
 
         console.log('✅ CLI prefers daemon when available');
@@ -759,6 +798,71 @@ async function testRunCliExplicitDaemonTimeout(): Promise<void> {
         });
 
         console.log('✅ CLI explicit daemon timeout');
+    } finally {
+        await daemon.close();
+    }
+}
+
+async function testRunCliImplicitDaemonTimeoutDoesNotRunTwice(): Promise<void> {
+    let localFetchCalls = 0;
+    const localRuntime = createOpenWebSearchRuntime({
+        config: createTestConfig(),
+        dependencies: {
+            fetchWebContent: async (url, maxChars) => {
+                localFetchCalls += 1;
+                return {
+                    url,
+                    finalUrl: url,
+                    contentType: 'text/plain',
+                    title: 'Local duplicate',
+                    retrievalMethod: 'request' as const,
+                    truncated: false,
+                    content: `local:${maxChars}`
+                };
+            }
+        }
+    });
+    const delayedRuntime = createOpenWebSearchRuntime({
+        config: createTestConfig(),
+        dependencies: {
+            fetchWebContent: async (url, maxChars) => {
+                await new Promise((resolve) => setTimeout(resolve, 250));
+                return {
+                    url,
+                    finalUrl: url,
+                    contentType: 'text/plain',
+                    title: 'Delayed daemon',
+                    retrievalMethod: 'browser-html' as const,
+                    truncated: false,
+                    content: `daemon:${maxChars}`
+                };
+            }
+        }
+    });
+    const daemon = await startLocalDaemon(delayedRuntime, { port: 0, version: 'implicit-timeout-test' });
+    const daemonPort = new URL(daemon.baseUrl).port;
+
+    try {
+        await withEnv('OPEN_WEBSEARCH_DAEMON_URL', undefined, async () => {
+            await withEnv('OPEN_WEBSEARCH_DAEMON_PORT', daemonPort, async () => {
+                await withEnv('OPEN_WEBSEARCH_DAEMON_ACTION_TIMEOUT_MS', '50', async () => {
+                    const stdout: string[] = [];
+                    const exitCode = await runCli(
+                        ['fetch-web', 'https://example.com', '--render-mode', 'browser', '--json'],
+                        localRuntime,
+                        { stdout: (text) => stdout.push(text), stderr: () => undefined }
+                    );
+
+                    const payload = JSON.parse(stdout[0]) as { status: string; error: { code: string } };
+                    assertEqual(exitCode, 1, 'CLI implicit daemon timeout exit code');
+                    assertEqual(payload.status, 'error', 'CLI implicit daemon timeout status');
+                    assertEqual(payload.error.code, 'daemon_timeout', 'CLI implicit daemon timeout code');
+                    assertEqual(localFetchCalls, 0, 'CLI should not re-run a timed out daemon request locally');
+                });
+            });
+        });
+
+        console.log('✅ CLI implicit daemon timeout does not duplicate fetch');
     } finally {
         await daemon.close();
     }
@@ -910,6 +1014,7 @@ async function testRunCliHelp(): Promise<void> {
     assert(stdout[0].includes('--search-mode'), 'CLI help should mention search-mode');
     assert(stdout[0].includes('--max-chars'), 'CLI help should mention max-chars');
     assert(stdout[0].includes('--readability'), 'CLI help should mention readability');
+    assert(stdout[0].includes('--render-mode'), 'CLI help should mention render mode');
     assert(stdout[0].includes('--include-links'), 'CLI help should mention include-links');
 
     console.log('✅ CLI help');
@@ -965,6 +1070,7 @@ async function main(): Promise<void> {
     await testRunCliPrefersDaemonWhenAvailable();
     await testRunCliExplicitDaemonUnavailable();
     await testRunCliExplicitDaemonTimeout();
+    await testRunCliImplicitDaemonTimeoutDoesNotRunTwice();
     await testRunCliSpawnStartsDaemon();
     console.log('\nCLI command tests passed.');
 }

--- a/src/test/test-cli-search.ts
+++ b/src/test/test-cli-search.ts
@@ -491,6 +491,60 @@ async function testRunCliFetchWebValidationFailure(): Promise<void> {
     console.log('✅ CLI runCli fetch-web validation failure');
 }
 
+async function testRunCliFetchWebBrowserUnavailable(): Promise<void> {
+    const runtime = createOpenWebSearchRuntime({
+        config: createTestConfig(),
+        dependencies: {
+            searchExecutors: {
+                bing: async (query, limit) => [{
+                    title: 'Result',
+                    url: 'https://example.com',
+                    description: `${query}:${limit}`,
+                    source: 'example.com',
+                    engine: 'bing'
+                }]
+            },
+            fetchGithubReadme: async () => '# README',
+            fetchWebContent: async () => {
+                const error = new Error(
+                    'Playwright client is not available: Install `playwright`/`playwright-core` manually or configure PLAYWRIGHT_MODULE_PATH.'
+                );
+                (error as Error & { code?: string }).code = 'browser_unavailable';
+                throw error;
+            },
+            fetchCsdnArticle: async () => ({ content: 'csdn' }),
+            fetchJuejinArticle: async () => ({ content: 'juejin' }),
+            fetchLinuxDoArticle: async () => ({ content: 'linuxdo' })
+        }
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const exitCode = await runCli(
+        ['fetch-web', 'https://example.com', '--render-mode', 'browser', '--json'],
+        runtime,
+        {
+            stdout: (text) => stdout.push(text),
+            stderr: (text) => stderr.push(text)
+        }
+    );
+
+    assertEqual(exitCode, 1, 'CLI fetch-web browser_unavailable exit code');
+    assertEqual(stderr.length, 0, 'CLI fetch-web browser_unavailable stderr');
+    const payload = JSON.parse(stdout[0]) as {
+        status: string;
+        error: { code: string; message: string };
+        hint?: string | null;
+    };
+    assertEqual(payload.status, 'error', 'CLI fetch-web browser_unavailable status');
+    assertEqual(payload.error.code, 'browser_unavailable', 'CLI fetch-web browser_unavailable code');
+    assert(
+        (payload.hint ?? '').includes('Playwright'),
+        'CLI fetch-web browser_unavailable hint should guide Playwright configuration'
+    );
+
+    console.log('✅ CLI runCli fetch-web browser_unavailable');
+}
+
 async function testRunCliFetchCsdnJsonSuccess(): Promise<void> {
     const runtime = createStubRuntime();
     const stdout: string[] = [];
@@ -1056,6 +1110,7 @@ async function main(): Promise<void> {
             await testRunCliFetchWebReadabilityJsonSuccess();
             await testRunCliFetchGithubReadmeJsonSuccess();
             await testRunCliFetchWebValidationFailure();
+            await testRunCliFetchWebBrowserUnavailable();
             await testRunCliFetchCsdnJsonSuccess();
             await testRunCliFetchJuejinJsonSuccess();
             await testRunCliFetchCsdnValidationFailure();

--- a/src/test/test-core-fetch-services.ts
+++ b/src/test/test-core-fetch-services.ts
@@ -22,12 +22,14 @@ async function testWebFetchService(): Promise<void> {
     let seenMaxChars = 0;
     let seenReadability: boolean | undefined;
     let seenIncludeLinks: boolean | undefined;
+    let seenRenderMode: string | undefined;
 
     const service = createWebFetchService(async (url, maxChars, options) => {
         seenUrl = url;
         seenMaxChars = maxChars;
         seenReadability = options?.readability;
         seenIncludeLinks = options?.includeLinks;
+        seenRenderMode = options?.renderMode;
         return {
             url,
             finalUrl: url,
@@ -45,13 +47,15 @@ async function testWebFetchService(): Promise<void> {
         url: 'https://example.com/docs',
         maxChars: 1234,
         readability: true,
-        includeLinks: true
+        includeLinks: true,
+        renderMode: 'browser'
     });
 
     assertEqual(seenUrl, 'https://example.com/docs', 'web fetch forwards url');
     assertEqual(seenMaxChars, 1234, 'web fetch forwards maxChars');
     assertEqual(seenReadability, true, 'web fetch forwards readability');
     assertEqual(seenIncludeLinks, true, 'web fetch forwards includeLinks');
+    assertEqual(seenRenderMode, 'browser', 'web fetch forwards renderMode');
     assertEqual(result.title, 'Example', 'web fetch returns delegate result');
     assertEqual(result.readabilityApplied, true, 'web fetch returns delegate readability result');
     assertEqual(result.links?.[0]?.href, 'https://example.com/doc', 'web fetch returns delegate links');

--- a/src/test/test-local-daemon.ts
+++ b/src/test/test-local-daemon.ts
@@ -61,17 +61,22 @@ function createStubRuntime() {
                 }]
             },
             fetchGithubReadme: async () => '# README',
-            fetchWebContent: async (url, maxChars, options) => ({
-                url,
-                finalUrl: url,
-                contentType: 'text/plain',
-                title: 'Example',
-                retrievalMethod: 'request' as const,
-                truncated: false,
-                content: `ok:${maxChars}:${options?.readability ? 'readability' : 'plain'}`,
-                readabilityApplied: options?.readability ?? false,
-                links: options?.includeLinks ? [{ text: 'Doc', href: 'https://example.com/doc' }] : undefined
-            }),
+            fetchWebContent: async (url, maxChars, options) => {
+                if (url.endsWith('/browser-unavailable')) {
+                    throw new Error('Playwright client is not available for browser HTML fetch');
+                }
+                return {
+                    url,
+                    finalUrl: url,
+                    contentType: 'text/plain',
+                    title: 'Example',
+                    retrievalMethod: 'request' as const,
+                    truncated: false,
+                    content: `ok:${maxChars}:${options?.readability ? 'readability' : 'plain'}:${options?.renderMode ?? 'auto'}`,
+                    readabilityApplied: options?.readability ?? false,
+                    links: options?.includeLinks ? [{ text: 'Doc', href: 'https://example.com/doc' }] : undefined
+                };
+            },
             fetchCsdnArticle: async () => ({ content: 'csdn' }),
             fetchJuejinArticle: async () => ({ content: 'juejin' }),
             fetchLinuxDoArticle: async () => ({ content: 'linuxdo' })
@@ -187,13 +192,29 @@ async function testLocalDaemonOperationRoutes(): Promise<void> {
             url: 'https://example.com',
             maxChars: 1234,
             readability: true,
-            includeLinks: true
+            includeLinks: true,
+            renderMode: 'browser'
         });
         assertEqual(fetchWebResult.response.status, 200, 'daemon /fetch-web http status');
         assertEqual(fetchWebResult.payload.status, 'ok', 'daemon /fetch-web payload status');
         assertEqual(fetchWebResult.payload.data.url, 'https://example.com', 'daemon /fetch-web url');
-        assertEqual(fetchWebResult.payload.data.content, 'ok:1234:readability', 'daemon /fetch-web content');
+        assertEqual(fetchWebResult.payload.data.content, 'ok:1234:readability:browser', 'daemon /fetch-web content');
         assertEqual((fetchWebResult.payload.data as { readabilityApplied?: boolean }).readabilityApplied, true, 'daemon /fetch-web readability flag');
+
+        const invalidRenderModeResult = await postJson<{ status: string; error: { code: string } }>(daemon.baseUrl, '/fetch-web', {
+            url: 'https://example.com',
+            renderMode: 'invalid'
+        });
+        assertEqual(invalidRenderModeResult.response.status, 400, 'daemon invalid renderMode http status');
+        assertEqual(invalidRenderModeResult.payload.status, 'error', 'daemon invalid renderMode payload status');
+        assertEqual(invalidRenderModeResult.payload.error.code, 'validation_failed', 'daemon invalid renderMode error code');
+
+        const browserUnavailableResult = await postJson<{ status: string; error: { code: string } }>(daemon.baseUrl, '/fetch-web', {
+            url: 'https://example.com/browser-unavailable',
+            renderMode: 'browser'
+        });
+        assertEqual(browserUnavailableResult.response.status, 503, 'daemon browser unavailable http status');
+        assertEqual(browserUnavailableResult.payload.error.code, 'browser_unavailable', 'daemon browser unavailable error code');
 
         const fetchGithubResult = await postJson<{
             status: string;

--- a/src/test/test-local-daemon.ts
+++ b/src/test/test-local-daemon.ts
@@ -65,6 +65,12 @@ function createStubRuntime() {
                 if (url.endsWith('/browser-unavailable')) {
                     throw new Error('Playwright client is not available for browser HTML fetch');
                 }
+                if (url.endsWith('/browser-launch-code')) {
+                    throw Object.assign(new Error('unable to spawn browser process'), { code: 'browser_unavailable' });
+                }
+                if (url.endsWith('/browser-remote-code')) {
+                    throw Object.assign(new Error('unexpected EOF from CDP endpoint'), { code: 'browser_unavailable' });
+                }
                 return {
                     url,
                     finalUrl: url,
@@ -215,6 +221,23 @@ async function testLocalDaemonOperationRoutes(): Promise<void> {
         });
         assertEqual(browserUnavailableResult.response.status, 503, 'daemon browser unavailable http status');
         assertEqual(browserUnavailableResult.payload.error.code, 'browser_unavailable', 'daemon browser unavailable error code');
+
+        // code 优先：message 不匹配历史正则时，仍应按 code 归类为 browser_unavailable（#107 review 反馈）。
+        const browserLaunchCodeResult = await postJson<{ status: string; error: { code: string; retryable: boolean } }>(daemon.baseUrl, '/fetch-web', {
+            url: 'https://example.com/browser-launch-code',
+            renderMode: 'browser'
+        });
+        assertEqual(browserLaunchCodeResult.response.status, 503, 'daemon browser launch code http status');
+        assertEqual(browserLaunchCodeResult.payload.error.code, 'browser_unavailable', 'daemon browser launch code error code');
+        assertEqual(browserLaunchCodeResult.payload.error.retryable, false, 'daemon browser launch code retryable');
+
+        const browserRemoteCodeResult = await postJson<{ status: string; error: { code: string; retryable: boolean } }>(daemon.baseUrl, '/fetch-web', {
+            url: 'https://example.com/browser-remote-code',
+            renderMode: 'browser'
+        });
+        assertEqual(browserRemoteCodeResult.response.status, 503, 'daemon browser remote code http status');
+        assertEqual(browserRemoteCodeResult.payload.error.code, 'browser_unavailable', 'daemon browser remote code error code');
+        assertEqual(browserRemoteCodeResult.payload.error.retryable, false, 'daemon browser remote code retryable');
 
         const fetchGithubResult = await postJson<{
             status: string;

--- a/src/test/test-mcp-adapter.ts
+++ b/src/test/test-mcp-adapter.ts
@@ -305,7 +305,7 @@ async function testSearchToolAutoModeUsesRuntimeDefault(): Promise<void> {
 }
 
 async function testFetchWebToolPassesReadabilityFlags(): Promise<void> {
-    const seenCalls: Array<{ readability?: boolean; includeLinks?: boolean }> = [];
+    const seenCalls: Array<{ readability?: boolean; includeLinks?: boolean; renderMode?: string }> = [];
     const runtime = createOpenWebSearchRuntime({
         config: createTestConfig(),
         dependencies: {
@@ -322,7 +322,8 @@ async function testFetchWebToolPassesReadabilityFlags(): Promise<void> {
             fetchWebContent: async (url, maxChars, options) => {
                 seenCalls.push({
                     readability: options?.readability,
-                    includeLinks: options?.includeLinks
+                    includeLinks: options?.includeLinks,
+                    renderMode: options?.renderMode
                 });
                 return {
                     url,
@@ -345,11 +346,15 @@ async function testFetchWebToolPassesReadabilityFlags(): Promise<void> {
     setupTools(server, runtime);
 
     const tools = (server as unknown as { _registeredTools: Record<string, { handler: (input: unknown) => Promise<{ content: Array<{ text: string }> }> }> })._registeredTools;
+    const fetchWebSchema = (tools.fetchWebContent as unknown as { inputSchema: { safeParse: (input: unknown) => { success: boolean } } }).inputSchema;
+    assert(fetchWebSchema.safeParse({ url: 'https://example.com', renderMode: 'browser' }).success, 'MCP fetch-web schema should accept browser renderMode');
+    assert(!fetchWebSchema.safeParse({ url: 'https://example.com', renderMode: 'invalid' }).success, 'MCP fetch-web schema should reject invalid renderMode');
     const response = await tools.fetchWebContent.handler({
         url: 'https://example.com',
         maxChars: 3000,
         readability: true,
-        includeLinks: true
+        includeLinks: true,
+        renderMode: 'browser'
     });
     const payload = JSON.parse(response.content[0].text) as {
         readabilityApplied?: boolean;
@@ -358,6 +363,7 @@ async function testFetchWebToolPassesReadabilityFlags(): Promise<void> {
 
     assertEqual(seenCalls[0].readability, true, 'MCP fetch-web should pass readability');
     assertEqual(seenCalls[0].includeLinks, true, 'MCP fetch-web should pass includeLinks');
+    assertEqual(seenCalls[0].renderMode, 'browser', 'MCP fetch-web should pass renderMode');
     assertEqual(payload.readabilityApplied, true, 'MCP fetch-web should expose readabilityApplied');
     assertEqual(payload.links?.[0]?.href, 'https://example.com/doc', 'MCP fetch-web should expose links');
 

--- a/src/test/test-web-content.ts
+++ b/src/test/test-web-content.ts
@@ -1,7 +1,10 @@
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { config } from '../config.js';
 import { __setBrowserHtmlFetcherForTests, fetchWebContent } from '../engines/web/index.js';
-import { __setReadabilityParserForTests } from '../engines/web/fetchWebContent.js';
+import {
+    __setBrowserCookieHeaderFetcherForTests,
+    __setReadabilityParserForTests
+} from '../engines/web/fetchWebContent.js';
 import { __setAxiosRequestForTests } from '../utils/httpRequest.js';
 import { __setDnsLookupForTests } from '../utils/urlSafety.js';
 
@@ -157,6 +160,7 @@ function installAxiosMock(): void {
 function restoreAxiosMock(): void {
     __setAxiosRequestForTests();
     __setBrowserHtmlFetcherForTests();
+    __setBrowserCookieHeaderFetcherForTests();
 }
 
 function assert(condition: unknown, message: string): void {
@@ -182,6 +186,9 @@ async function main(): Promise<void> {
     __setDnsLookupForTests(async (hostname) => {
         if (hostname === 'example.com') {
             return [{ address: '93.184.216.34' }];
+        }
+        if (hostname === 'private-final.example') {
+            return [{ address: '127.0.0.1' }];
         }
         throw new Error(`unexpected hostname: ${hostname}`);
     });
@@ -255,6 +262,168 @@ async function main(): Promise<void> {
                 assert(result.retrievalMethod === 'browser-html', 'browser html fallback should be reported');
                 assert(result.finalUrl.endsWith('rendered=1'), 'browser fallback finalUrl should be used');
                 assert(result.content.includes('Rendered browser content'), 'browser html content should replace shell metadata');
+            }
+        },
+        {
+            name: 'auto mode should keep request metadata when browser fallback fails',
+            run: async () => {
+                let browserCalls = 0;
+                __setBrowserHtmlFetcherForTests(async () => {
+                    browserCalls += 1;
+                    throw new Error('browser unavailable');
+                });
+
+                const result = await fetchWebContent('https://example.com/browser-spa', 5000, {
+                    renderMode: 'auto'
+                });
+                assert(result.retrievalMethod === 'request', 'failed auto fallback should retain request retrieval');
+                assert(result.content.includes('JS bootstrap shell'), 'failed auto fallback should retain request metadata');
+                assert(browserCalls === 1, 'auto mode should attempt browser fallback exactly once');
+            }
+        },
+        {
+            name: 'request mode should never invoke browser fallback for shell html',
+            run: async () => {
+                let browserCalled = false;
+                __setBrowserHtmlFetcherForTests(async () => {
+                    browserCalled = true;
+                    throw new Error('request mode must not use browser');
+                });
+
+                const result = await fetchWebContent('https://example.com/browser-spa', 5000, {
+                    renderMode: 'request'
+                });
+                assert(result.retrievalMethod === 'request', 'request mode should report request retrieval');
+                assert(result.content.includes('JS bootstrap shell'), 'request mode should preserve request metadata result');
+                assert(browserCalled === false, 'request mode should not invoke browser fetcher');
+            }
+        },
+        {
+            name: 'request mode should not use browser assistance for blocked responses',
+            run: async () => {
+                let cookieCalled = false;
+                let browserCalled = false;
+                __setBrowserCookieHeaderFetcherForTests(async () => {
+                    cookieCalled = true;
+                    return 'session=unexpected';
+                });
+                __setBrowserHtmlFetcherForTests(async () => {
+                    browserCalled = true;
+                    throw new Error('request mode must not use browser');
+                });
+
+                let failed = false;
+                try {
+                    await fetchWebContent('https://example.com/blocked-browser-spa', 5000, {
+                        renderMode: 'request'
+                    });
+                } catch {
+                    failed = true;
+                }
+                assert(failed, 'request mode should surface the blocked request error');
+                assert(cookieCalled === false, 'request mode should not request browser cookies');
+                assert(browserCalled === false, 'request mode should not invoke browser html fallback');
+            }
+        },
+        {
+            name: 'browser mode should render directly without request traffic',
+            run: async () => {
+                __setBrowserHtmlFetcherForTests(async () => ({
+                    html: `
+                    <html>
+                      <head><title>Direct Browser Page</title></head>
+                      <body><main><p>${'Direct rendered content '.repeat(12)}</p></main></body>
+                    </html>
+                    `,
+                    finalUrl: 'https://example.com/direct-browser?rendered=1',
+                    title: 'Direct Browser Page'
+                }));
+
+                const requestsBefore = Array.from(requestConfigs.values()).reduce((sum, calls) => sum + calls.length, 0);
+                const result = await fetchWebContent('https://example.com/direct-browser', 5000, {
+                    renderMode: 'browser'
+                });
+                const requestsAfter = Array.from(requestConfigs.values()).reduce((sum, calls) => sum + calls.length, 0);
+
+                assert(requestsAfter === requestsBefore, 'browser mode should not issue HEAD or GET requests');
+                assert(result.retrievalMethod === 'browser-html', 'browser mode should report browser-html retrieval');
+                assert(result.title === 'Direct Browser Page', 'browser mode should preserve rendered title');
+                assert(result.finalUrl.endsWith('rendered=1'), 'browser mode should preserve final browser URL');
+                assert(result.content.includes('Direct rendered content'), 'browser mode should extract rendered content');
+            }
+        },
+        {
+            name: 'browser mode should extract browser html for markdown-looking paths',
+            run: async () => {
+                __setBrowserHtmlFetcherForTests(async () => ({
+                    html: `<html><head><title>Rendered Markdown Route</title></head><body><main><p>${'Rendered route body '.repeat(12)}</p></main></body></html>`,
+                    finalUrl: 'https://example.com/rendered.md',
+                    title: 'Rendered Markdown Route'
+                }));
+
+                const result = await fetchWebContent('https://example.com/rendered.md', 5000, {
+                    renderMode: 'browser'
+                });
+                assert(result.content.includes('Rendered route body'), 'browser .md route should extract html text');
+                assert(!result.content.includes('<html>'), 'browser .md route should not return raw html as markdown');
+            }
+        },
+        {
+            name: 'browser mode should surface browser availability errors',
+            run: async () => {
+                __setBrowserHtmlFetcherForTests(async () => {
+                    throw new Error('Playwright client is not available for browser HTML fetch');
+                });
+
+                let message = '';
+                try {
+                    await fetchWebContent('https://example.com/browser-required', 5000, {
+                        renderMode: 'browser'
+                    });
+                } catch (error) {
+                    message = error instanceof Error ? error.message : String(error);
+                }
+                assert(message.includes('Playwright client is not available'), 'browser mode should surface Playwright errors');
+            }
+        },
+        {
+            name: 'browser mode should reject a final URL that resolves to a private address',
+            run: async () => {
+                __setBrowserHtmlFetcherForTests(async () => ({
+                    html: '<html><body><main>private redirect</main></body></html>',
+                    finalUrl: 'https://private-final.example/page',
+                    title: 'Private Redirect'
+                }));
+
+                let failed = false;
+                try {
+                    await fetchWebContent('https://example.com/browser-redirect', 5000, {
+                        renderMode: 'browser'
+                    });
+                } catch {
+                    failed = true;
+                }
+                assert(failed, 'browser mode should reject DNS-resolved private final URLs');
+            }
+        },
+        {
+            name: 'browser mode should reject oversized rendered html',
+            run: async () => {
+                __setBrowserHtmlFetcherForTests(async () => ({
+                    html: `<html><body>${'x'.repeat(2 * 1024 * 1024)}</body></html>`,
+                    finalUrl: 'https://example.com/oversized-browser',
+                    title: 'Oversized'
+                }));
+
+                let failed = false;
+                try {
+                    await fetchWebContent('https://example.com/oversized-browser', 5000, {
+                        renderMode: 'browser'
+                    });
+                } catch {
+                    failed = true;
+                }
+                assert(failed, 'browser mode should enforce the rendered html byte limit');
             }
         },
         {
@@ -378,6 +547,7 @@ async function main(): Promise<void> {
     config.fetchWebAllowInsecureTls = originalFetchWebAllowInsecureTls;
     __setReadabilityParserForTests();
     __setBrowserHtmlFetcherForTests();
+    __setBrowserCookieHeaderFetcherForTests();
 
     const total = testCases.length;
     console.log(`\nResult: ${passed}/${total} passed`);
@@ -395,6 +565,7 @@ main().catch((error) => {
     config.fetchWebAllowInsecureTls = false;
     __setReadabilityParserForTests();
     __setBrowserHtmlFetcherForTests();
+    __setBrowserCookieHeaderFetcherForTests();
     console.error('❌ test-web-content failed:', error);
     process.exit(1);
 });

--- a/src/tools/setupTools.ts
+++ b/src/tools/setupTools.ts
@@ -298,7 +298,7 @@ export const setupTools = (server: McpServer, runtime: OpenWebSearchRuntime): vo
     // 获取通用网页/Markdown 内容工具
     server.tool(
         fetchWebToolName,
-        "Fetch content from a public HTTP(S) URL (supports Markdown files and normal web pages)",
+        "Fetch content from a public HTTP(S) URL. renderMode defaults to auto: request uses HTTP only, auto uses request with browser fallback, and browser renders directly with Playwright and fails clearly when Playwright is unavailable.",
         {
             url: z.string().url().refine(
                 (url) => validatePublicWebUrl(url),
@@ -306,12 +306,13 @@ export const setupTools = (server: McpServer, runtime: OpenWebSearchRuntime): vo
             ),
             maxChars: z.number().int().min(1000).max(200000).default(30000),
             readability: z.boolean().optional(),
-            includeLinks: z.boolean().optional()
+            includeLinks: z.boolean().optional(),
+            renderMode: z.enum(['request', 'auto', 'browser']).optional()
         },
-        async ({url, maxChars = 30000, readability, includeLinks}) => {
+        async ({url, maxChars = 30000, readability, includeLinks, renderMode}) => {
             try {
                 console.error(`Fetching web content: ${url}`);
-                const result = await runtime.services.fetchWeb.execute({ url, maxChars, readability, includeLinks });
+                const result = await runtime.services.fetchWeb.execute({ url, maxChars, readability, includeLinks, renderMode });
 
                 return {
                     content: [{

--- a/src/utils/browserCookies.ts
+++ b/src/utils/browserCookies.ts
@@ -5,6 +5,7 @@ import { assertPublicHttpUrl, assertPublicHttpUrlResolved } from './urlSafety.js
 
 const COOKIE_CACHE_TTL_MS = 10 * 60 * 1000;
 const COOKIE_WARMUP_DELAY_MS = 1200;
+export const MAX_BROWSER_HTML_BYTES = 2 * 1024 * 1024;
 const COOKIE_CONTEXT_OPTIONS = {
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36',
     locale: 'zh-CN',
@@ -57,9 +58,8 @@ export function looksLikeBotChallengePage(html: string): boolean {
     return BOT_KEYWORDS.some((keyword) => normalized.includes(keyword));
 }
 
-// Hostname-level TTL cache used by the subresource guard so a page loading
-// N assets from one CDN costs one DNS lookup, not N. Bounded to keep memory
-// capped; short TTL shrinks the DNS-rebinding window for subresources.
+// Cache only blocked hostname classifications. Public resolutions are checked
+// on every request so DNS rebinding cannot reuse an earlier allow decision.
 const SUBRESOURCE_CLASSIFICATION_TTL_MS = 60 * 1000;
 const SUBRESOURCE_CLASSIFICATION_MAX_ENTRIES = 1024;
 type SubresourceClassification = { allowed: boolean; expiresAt: number };
@@ -77,7 +77,7 @@ function readSubresourceClassification(hostname: string): boolean | undefined {
     return entry.allowed;
 }
 
-function writeSubresourceClassification(hostname: string, allowed: boolean): void {
+function writeBlockedSubresourceClassification(hostname: string): void {
     if (subresourceClassificationCache.size >= SUBRESOURCE_CLASSIFICATION_MAX_ENTRIES) {
         // Map preserves insertion order; drop the oldest.
         const oldestKey = subresourceClassificationCache.keys().next().value;
@@ -86,14 +86,13 @@ function writeSubresourceClassification(hostname: string, allowed: boolean): voi
         }
     }
     subresourceClassificationCache.set(hostname, {
-        allowed,
+        allowed: false,
         expiresAt: Date.now() + SUBRESOURCE_CLASSIFICATION_TTL_MS
     });
 }
 
-// Async variant for sub-resource requests. Uses the TTL cache so that common
-// page-load patterns (dozens of assets from one CDN) don't trigger one DNS
-// lookup per asset, while hostname-to-private resolutions are still caught.
+// Async variant for sub-resource requests. Denials are cached, while allowed
+// hosts are resolved on each request to remain fail-closed under DNS rebinding.
 export async function classifyBrowserSubresourceUrl(targetUrl: string): Promise<void> {
     const parsed = new URL(targetUrl);
     // Protocol + literal-IP private check first (sync, free).
@@ -107,18 +106,14 @@ export async function classifyBrowserSubresourceUrl(targetUrl: string): Promise<
 
     const cacheKey = hostname.toLowerCase();
     const cached = readSubresourceClassification(cacheKey);
-    if (cached === true) {
-        return;
-    }
     if (cached === false) {
         throw new Error('Browser subresource URL points to a private or local network target, which is not allowed');
     }
 
     try {
         await assertPublicHttpUrlResolved(parsed, 'Browser subresource URL');
-        writeSubresourceClassification(cacheKey, true);
     } catch (err) {
-        writeSubresourceClassification(cacheKey, false);
+        writeBlockedSubresourceClassification(cacheKey);
         throw err;
     }
 }
@@ -131,13 +126,17 @@ export function __getBrowserSubresourceClassificationForTests(hostname: string):
     return subresourceClassificationCache.get(hostname.toLowerCase())?.allowed;
 }
 
+export async function __installNavigationGuardForTests(page: any): Promise<void> {
+    await installNavigationGuard(page);
+}
+
 // Intercepts every request the page makes (navigation + sub-resources) and
 // aborts ones whose target is private/loopback at either the literal or
 // DNS-resolved level. Navigation hits DNS fresh every time to keep the
 // rebinding window tight; sub-resources go through a hostname TTL cache.
 async function installNavigationGuard(page: any): Promise<void> {
     if (typeof page.route !== 'function') {
-        return;
+        throw new Error('Browser request interception is unavailable; refusing browser navigation because public-network safety cannot be enforced');
     }
     try {
         await page.route('**/*', async (route: any) => {
@@ -154,9 +153,9 @@ async function installNavigationGuard(page: any): Promise<void> {
                 await route.abort().catch(() => undefined);
             }
         });
-    } catch {
-        // Some connected browsers (e.g., certain CDP setups) may not support route
-        // interception. Pre-navigation validation still gates the initial URL.
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Browser request interception could not be installed; refusing browser navigation because public-network safety cannot be enforced: ${message}`);
     }
 }
 
@@ -166,8 +165,9 @@ async function createCookieCollectionPage(browser: any): Promise<{ page: any; cl
     // 但 connectOverCDP 返回的浏览器通常只有一个默认持久化 context，不支持 newContext()，
     // 所以当 newContext 不可用时回退到默认 context + 手动清理。
     if (typeof browser.newContext === 'function') {
+        let context: any;
         try {
-            const context = await browser.newContext(COOKIE_CONTEXT_OPTIONS);
+            context = await browser.newContext(COOKIE_CONTEXT_OPTIONS);
             const page = await context.newPage();
             return {
                 page,
@@ -176,6 +176,9 @@ async function createCookieCollectionPage(browser: any): Promise<{ page: any; cl
                 }
             };
         } catch {
+            if (context && typeof context.close === 'function') {
+                await context.close().catch(() => undefined);
+            }
             // newContext 可能在 CDP 连接上抛异常，回退到默认 context
         }
     }
@@ -199,6 +202,10 @@ async function createCookieCollectionPage(browser: any): Promise<{ page: any; cl
     }
 
     throw new Error('Browser does not support creating a page for cookie collection');
+}
+
+export async function __createCookieCollectionPageForTests(browser: any): Promise<{ page: any; close(): Promise<void> }> {
+    return await createCookieCollectionPage(browser);
 }
 
 async function readCookiesFromPage(page: any, url: string): Promise<string> {
@@ -295,6 +302,15 @@ export async function fetchPageHtmlWithBrowser(urlInput: string): Promise<{ html
 
             if (typeof page.waitForTimeout === 'function') {
                 await page.waitForTimeout(COOKIE_WARMUP_DELAY_MS).catch(() => undefined);
+            }
+
+            if (typeof page.evaluate === 'function') {
+                const estimatedHtmlBytes = await page.evaluate(() => new Blob([
+                    document.documentElement?.outerHTML || ''
+                ]).size);
+                if (Number(estimatedHtmlBytes) > MAX_BROWSER_HTML_BYTES) {
+                    throw new Error(`Response body too large (${estimatedHtmlBytes} bytes). Max allowed is ${MAX_BROWSER_HTML_BYTES} bytes`);
+                }
             }
 
             const html = typeof page.content === 'function' ? await page.content() : '';

--- a/src/utils/playwrightClient.ts
+++ b/src/utils/playwrightClient.ts
@@ -2283,6 +2283,22 @@ export function asBrowserUnavailableError(error: unknown, context: string): Erro
     return wrapped;
 }
 
+/** 已知的浏览器不可用消息特征，作为未带 code 的历史错误回退。 */
+const BROWSER_UNAVAILABLE_MESSAGE_RE =
+    /Playwright client is not available|No Chromium-based browser executable|request interception (?:is unavailable|could not be installed)|connect(?:ion)? (?:failed|refused|timed out)/i;
+
+/**
+ * 判定错误是否为浏览器不可用：优先看 code（各入口用 asBrowserUnavailableError 统一打标），
+ * 其次回退到已知消息特征。daemon 与 CLI 共用同一判定，避免两边分类漂移。
+ */
+export function isBrowserUnavailableError(error: unknown): boolean {
+    if ((error as { code?: unknown })?.code === 'browser_unavailable') {
+        return true;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return BROWSER_UNAVAILABLE_MESSAGE_RE.test(message);
+}
+
 export async function openPlaywrightBrowser(
     options?: { antiBot?: boolean }
 ): Promise<PlaywrightBrowserSession> {


### PR DESCRIPTION
## Summary

- add `renderMode: request | auto | browser` to `fetchWebContent`, keeping `auto` as the default
- expose the option consistently through MCP, CLI, local daemon, and core runtime APIs
- make explicit browser rendering fail clearly when Playwright is unavailable and preserve request-only behavior in `request` mode
- strengthen browser request interception, final URL validation, response size limits, daemon timeout handling, and browser context cleanup
- update English/Chinese docs and bundled skill guidance

Closes #89.

## Verification

- `npm run build`
- `npm test`: 30 deterministic tests passed; 2 live network tests were excused by the repository runner because this machine resolves their targets through a fake-IP DNS range
- focused suites: `test:web-content` (19/19), `test:browser-path-guard`, `test:core-fetch-services`, `test:mcp-adapter`, `test:local-daemon`, `test:cli-search`, `test:url-safety`, `test:redirect-safety`
- real Chromium smoke against `https://quotes.toscrape.com/js/`: `renderMode=browser` returned `retrievalMethod=browser-html`, 1,535 characters, and JS-rendered Albert Einstein content
- `git diff --check`

## Security note

Browser navigation reuses the existing route-time public-network validation and now fails closed when interception is unavailable. Public hosts are re-resolved for subsequent requests, final URLs are validated, and rendered HTML is limited before and after CDP serialization. As documented, DNS validation is not socket pinning; remote Playwright/CDP endpoints still need trusted DNS and egress policy.

## Related work

PR #101 refactors browser lifecycle internals but does not implement this public `renderMode` contract. This change stays on the existing `fetchPageHtmlWithBrowser` boundary so it can be rebased narrowly if #101 lands first.

OpenAI Codex assisted with implementation, test design, and review. I reviewed and verified the submitted changes.
