### PR TITLE
feat(search): add Hacker News engine

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -126,6 +126,7 @@ MCP工具支持：
     - juejin
     - startpage
     - sogou
+    - hackernews
 - 支持HTTP代理配置，轻松解决网络访问限制
 - 无需API密钥或身份验证
 - 返回带标题、URL和描述的结构化结果
@@ -223,7 +224,7 @@ npm run search:cli -- "open web search" --json
 本地 daemon HTTP API（`serve`、`status`、`GET /health`、`POST /search`、`POST /fetch-*`）请参考 [docs/http-api.md](docs/http-api.md)。
 
 ## TODO
-- 支持~~Bing~~（已支持）,~~DuckDuckGo~~（已支持）,~~Exa~~（已支持）,~~Brave~~（已支持）,~~Sogou~~（已支持）,Google等搜索引擎
+- 支持~~Bing~~（已支持）,~~DuckDuckGo~~（已支持）,~~Exa~~（已支持）,~~Brave~~（已支持）,~~Sogou~~（已支持）,~~Hacker News~~（已支持）,Google等搜索引擎
 - 支持更多博客论坛、社交软件
 - 优化文章内容提取功能，增加更多站点支持
 - ~~支持GitHub README获取~~（已支持）
@@ -261,7 +262,7 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 |--------|-------------------------|--------|--------------------------------------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | 启用CORS                               |
 | `CORS_ORIGIN` | `*`                     | 任何有效来源 | CORS来源配置                             |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | 默认搜索引擎                               |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `linuxdo`, `juejin`, `startpage`, `sogou`, `hackernews` | 默认搜索引擎                               |
 | `USE_PROXY` | `false`                 | `true`, `false` | 启用HTTP代理                             |
 | `PROXY_URL` | `http://127.0.0.1:7890` | 任何有效URL | 代理服务器URL                             |
 | `FETCH_WEB_INSECURE_TLS` | `false` | `true`, `false` | 仅对 `fetchWebContent` 关闭 TLS 证书校验。只建议在目标站点证书链异常时临时使用 |
@@ -525,7 +526,7 @@ docker run -d --name web-search -p 3000:3000 -e ENABLE_CORS=true -e CORS_ORIGIN=
 |--------|-------------------------|--------|------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | 启用CORS |
 | `CORS_ORIGIN` | `*`                     | 任何有效来源 | CORS来源配置 |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | 默认搜索引擎 |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `linuxdo`, `juejin`, `startpage`, `sogou`, `hackernews` | 默认搜索引擎 |
 | `USE_PROXY` | `false`                 | `true`, `false` | 启用HTTP代理 |
 | `PROXY_URL` | `http://127.0.0.1:7890` | 任何有效URL | 代理服务器URL |
 | `PORT` | `3000`                  | 1-65535 | 服务器端口 |
@@ -566,7 +567,7 @@ docker run -d --name web-search -p 3000:3000 -e ENABLE_CORS=true -e CORS_ORIGIN=
 {
   "query": string,        // 搜索查询词
   "limit": number,        // 可选：返回结果数量（默认：10）
-  "engines": string[],    // 可选：使用的引擎 (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage,sogou) 默认使用当前运行配置
+  "engines": string[],    // 可选：使用的引擎 (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage,sogou,hackernews) 默认使用当前运行配置
   "searchMode": string    // 可选：request、auto 或 playwright（当前仅对 Bing 生效）
 }
 ```
@@ -789,7 +790,7 @@ use_mcp_tool({
 
 4. **搜索引擎配置**：
    - 可通过环境变量`DEFAULT_SEARCH_ENGINE`设置默认搜索引擎
-   - 支持的引擎有：bing, duckduckgo, exa, brave, baidu, csdn, juejin, startpage, sogou
+   - 支持的引擎有：bing, duckduckgo, exa, brave, baidu, csdn, linuxdo, juejin, startpage, sogou, hackernews
    - 当搜索特定网站内容时，会自动使用默认搜索引擎
 
 5. **代理服务配置**：

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
     - juejin
     - startpage
     - sogou
+    - hackernews
 - HTTP proxy configuration support for accessing restricted resources
 - No API keys or authentication required
 - Returns structured results with titles, URLs, and descriptions
@@ -134,7 +135,7 @@ Notes:
 For the local daemon HTTP API (`serve`, `status`, `GET /health`, `POST /search`, `POST /fetch-*`), see [docs/http-api.md](docs/http-api.md).
 
 ## TODO
-- Support for ~~Bing~~ (already supported), ~~DuckDuckGo~~ (already supported), ~~Exa~~ (already supported), ~~Brave~~ (already supported), ~~Sogou~~ (already supported), Google and other search engines
+- Support for ~~Bing~~ (already supported), ~~DuckDuckGo~~ (already supported), ~~Exa~~ (already supported), ~~Brave~~ (already supported), ~~Sogou~~ (already supported), ~~Hacker News~~ (already supported), Google and other search engines
 - Support for more blogs, forums, and social platforms
 - Optimize article content extraction, add support for more sites
 - ~~Support for GitHub README fetching~~ (already supported)
@@ -171,7 +172,7 @@ npx cross-env DEFAULT_SEARCH_ENGINE=duckduckgo ENABLE_CORS=true open-websearch
 |----------|-------------------------|---------|-------------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | Enable CORS |
 | `CORS_ORIGIN` | `*`                     | Any valid origin | CORS origin configuration |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | Default search engine |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `linuxdo`, `juejin`, `startpage`, `sogou`, `hackernews` | Default search engine |
 | `USE_PROXY` | `false`                 | `true`, `false` | Enable HTTP proxy |
 | `PROXY_URL` | `http://127.0.0.1:7890` | Any valid URL | Proxy server URL |
 | `FAKE_IP_CIDRS` | empty | Comma-separated CIDR list | Treat DNS answers in these CIDRs as synthetic fake-IP results and do not block them as private-network DNS answers. Literal private/local targets and other private-network DNS answers remain blocked |
@@ -433,7 +434,7 @@ Environment variable configuration:
 |----------|-------------------------|---------|-------------|
 | `ENABLE_CORS` | `false`                 | `true`, `false` | Enable CORS |
 | `CORS_ORIGIN` | `*`                     | Any valid origin | CORS origin configuration |
-| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `juejin`, `startpage`, `sogou` | Default search engine |
+| `DEFAULT_SEARCH_ENGINE` | `bing`                  | `bing`, `duckduckgo`, `exa`, `brave`, `baidu`, `csdn`, `linuxdo`, `juejin`, `startpage`, `sogou`, `hackernews` | Default search engine |
 | `USE_PROXY` | `false`                 | `true`, `false` | Enable HTTP proxy |
 | `PROXY_URL` | `http://127.0.0.1:7890` | Any valid URL | Proxy server URL |
 | `FAKE_IP_CIDRS` | empty | Comma-separated CIDR list | Treat DNS answers in these CIDRs as synthetic fake-IP results and do not block them as private-network DNS answers. Literal private/local targets and other private-network DNS answers remain blocked |
@@ -475,7 +476,7 @@ For the local daemon HTTP API (`serve`, `status`, `GET /health`, `POST /search`,
 {
   "query": string,        // Search query
   "limit": number,        // Optional: Number of results to return (default: 10)
-  "engines": string[],    // Optional: Engines to use (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage,sogou) default runtime-configured engine
+  "engines": string[],    // Optional: Engines to use (bing,baidu,linuxdo,csdn,duckduckgo,exa,brave,juejin,startpage,sogou,hackernews) default runtime-configured engine
   "searchMode": string    // Optional: request, auto, or playwright (currently only affects Bing)
 }
 ```
@@ -693,7 +694,7 @@ Since this tool works by scraping multi-engine search results, please note the f
 
 4. **Search Engine Configuration**:
    - Default search engine can be set via the `DEFAULT_SEARCH_ENGINE` environment variable
-   - Supported engines: bing, duckduckgo, exa, brave, baidu, csdn, juejin, startpage, sogou
+   - Supported engines: bing, duckduckgo, exa, brave, baidu, csdn, linuxdo, juejin, startpage, sogou, hackernews
    - The default engine is used when searching specific websites
 
 5. **Proxy Configuration**:

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -140,8 +140,8 @@ Request body:
 ```json
 {
   "query": "open web search",
-  "limit": 3,
-  "engines": ["startpage", "bing", "sogou"],
+  "limit": 4,
+  "engines": ["startpage", "bing", "sogou", "hackernews"],
   "searchMode": "playwright"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:mcp-adapter": "tsc && node build/test/test-mcp-adapter.js",
     "test:runtime": "tsc && node build/test/test-runtime.js",
     "test:sogou": "tsc && node build/test/test-sogou.js",
+    "test:hackernews": "tsc && node build/test/test-hackernews.js",
     "test:startpage": "tsc && node build/test/test-startpage.js",
     "test:http-request-options": "tsc && node build/test/test-http-request-options.js",
     "test:url-safety": "tsc && node build/test/test-url-safety.js",

--- a/skills/open-websearch/references/engine-selection.md
+++ b/skills/open-websearch/references/engine-selection.md
@@ -13,6 +13,10 @@ Engine choice is heuristic, not mandatory. If a preferred engine is unavailable,
 - Use `csdn` for developer blog content and tutorial-style posts.
 - Use `juejin` for Chinese developer posts and frontend/backend engineering topics.
 
+## Community discussions
+
+- Use `hackernews` for Hacker News stories and technology-community discussions. Results link to the submitted page when available and otherwise to the Hacker News discussion.
+
 ## Source-specific retrieval
 
 - Use `fetchGithubReadme` for GitHub repositories.

--- a/skills/open-websearch/references/tools.md
+++ b/skills/open-websearch/references/tools.md
@@ -15,6 +15,7 @@ Returns:
 Good follow-up actions:
 - fetch one or more result URLs with `fetchWebContent`
 - fetch a repository with `fetchGithubReadme`
+- use the `hackernews` engine when the goal is specifically to find Hacker News stories or discussions
 - if Bing Playwright mode returns no results for a `site:` query, retry once without the `site:` prefix before assuming the search target is empty
 
 ## `fetchWebContent`

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import ipaddr from 'ipaddr.js';
 
 export interface AppConfig {
     // Search engine configuration
-    defaultSearchEngine: 'bing' | 'duckduckgo' | 'exa' | 'brave' | 'baidu' | 'csdn' | 'linuxdo'  | 'juejin' | 'startpage' | 'sogou';
+    defaultSearchEngine: 'bing' | 'duckduckgo' | 'exa' | 'brave' | 'baidu' | 'csdn' | 'linuxdo'  | 'juejin' | 'startpage' | 'sogou' | 'hackernews';
     // List of allowed search engines (if empty, all engines are available)
     allowedSearchEngines: string[];
     // Search mode: request only, auto request then fallback, or force Playwright
@@ -74,7 +74,7 @@ export const config: AppConfig = {
 };
 
 // Valid search engines list
-const validSearchEngines = ['bing', 'duckduckgo', 'exa', 'brave', 'baidu', 'csdn', 'linuxdo', 'juejin', 'startpage', 'sogou'];
+const validSearchEngines = ['bing', 'duckduckgo', 'exa', 'brave', 'baidu', 'csdn', 'linuxdo', 'juejin', 'startpage', 'sogou', 'hackernews'];
 const validSearchModes = ['request', 'auto', 'playwright'];
 const validPlaywrightPackages = ['auto', 'playwright', 'playwright-core'];
 const quietStartupLogs = process.env.OPEN_WEBSEARCH_QUIET_STARTUP === 'true';

--- a/src/core/search/searchEngines.ts
+++ b/src/core/search/searchEngines.ts
@@ -8,7 +8,8 @@ export const SUPPORTED_SEARCH_ENGINES = [
     'brave',
     'juejin',
     'startpage',
-    'sogou'
+    'sogou',
+    'hackernews'
 ] as const;
 
 export type SupportedSearchEngine = typeof SUPPORTED_SEARCH_ENGINES[number];
@@ -40,6 +41,9 @@ export function normalizeEngineName(engine: string): string {
         case 'sougou':
         case '搜狗':
             return 'sogou';
+        case 'hackernews':
+        case 'hn':
+            return 'hackernews';
         default:
             return cleaned;
     }

--- a/src/engines/hackernews/hackernews.ts
+++ b/src/engines/hackernews/hackernews.ts
@@ -1,0 +1,190 @@
+import axios from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as cheerio from 'cheerio';
+import { SearchResult } from '../../types.js';
+import { buildAxiosRequestOptions } from '../../utils/httpRequest.js';
+import { isPrivateOrLocalHostname } from '../../utils/urlSafety.js';
+
+const HACKER_NEWS_SEARCH_URL = 'https://hn.algolia.com/api/v1/search';
+const HACKER_NEWS_ITEM_URL = 'https://news.ycombinator.com/item';
+const HACKER_NEWS_MAX_RESULTS = 50;
+
+type HackerNewsHttpGet = (url: string, options: AxiosRequestConfig) => Promise<AxiosResponse>;
+
+type HackerNewsHit = {
+    objectID?: unknown;
+    title?: unknown;
+    url?: unknown;
+    author?: unknown;
+    points?: unknown;
+    num_comments?: unknown;
+    created_at?: unknown;
+    story_text?: unknown;
+};
+
+let hackerNewsHttpGet: HackerNewsHttpGet = (url, options) => axios.get(url, options);
+
+export function __setHackerNewsHttpGetForTests(impl?: HackerNewsHttpGet): void {
+    hackerNewsHttpGet = impl ?? ((url, options) => axios.get(url, options));
+}
+
+function readText(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function parseHttpResultUrl(value: unknown): URL | undefined {
+    const rawUrl = readText(value);
+    if (!rawUrl) {
+        return undefined;
+    }
+
+    try {
+        const parsed = new URL(rawUrl);
+        if (
+            (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+            && !parsed.username
+            && !parsed.password
+            && !isPrivateOrLocalHostname(parsed.hostname)
+        ) {
+            return parsed;
+        }
+    } catch {
+        // Malformed upstream URLs fall back to the Hacker News discussion page.
+    }
+
+    return undefined;
+}
+
+function readObjectId(value: unknown): string {
+    const objectId = readText(value);
+    return /^\d+$/.test(objectId) ? objectId : '';
+}
+
+function buildDescription(hit: HackerNewsHit): string {
+    const metadata: string[] = [];
+    const author = readText(hit.author);
+    const points = readFiniteNumber(hit.points);
+    const comments = readFiniteNumber(hit.num_comments);
+    const createdAt = readText(hit.created_at);
+
+    if (author) {
+        metadata.push(`By ${author}`);
+    }
+    if (points !== undefined) {
+        metadata.push(`${points} point${points === 1 ? '' : 's'}`);
+    }
+    if (comments !== undefined) {
+        metadata.push(`${comments} comment${comments === 1 ? '' : 's'}`);
+    }
+    if (createdAt) {
+        const timestamp = Date.parse(createdAt);
+        if (Number.isFinite(timestamp)) {
+            metadata.push(new Date(timestamp).toISOString().slice(0, 10));
+        }
+    }
+
+    const storyText = readText(hit.story_text);
+    let summary = '';
+    if (storyText) {
+        const $ = cheerio.load(storyText);
+        $('script, style').remove();
+        $('br').replaceWith(' ');
+        $('p, div, li, blockquote, pre, h1, h2, h3, h4, h5, h6').each((_, element) => {
+            $(element).append(' ');
+        });
+        summary = $('body').text().replace(/\s+/g, ' ').trim().slice(0, 500);
+    }
+
+    return [summary, ...metadata].filter(Boolean).join(' | ');
+}
+
+function mapHackerNewsHit(hit: unknown): SearchResult | undefined {
+    if (!hit || typeof hit !== 'object' || Array.isArray(hit)) {
+        return undefined;
+    }
+
+    const candidate = hit as HackerNewsHit;
+    const title = readText(candidate.title);
+    if (!title) {
+        return undefined;
+    }
+
+    const objectId = readObjectId(candidate.objectID);
+    const externalUrl = parseHttpResultUrl(candidate.url);
+    const resultUrl = externalUrl?.toString()
+        ?? (objectId ? `${HACKER_NEWS_ITEM_URL}?id=${encodeURIComponent(objectId)}` : '');
+    if (!resultUrl) {
+        return undefined;
+    }
+
+    return {
+        title,
+        url: resultUrl,
+        description: buildDescription(candidate),
+        source: externalUrl?.hostname || 'news.ycombinator.com',
+        engine: 'hackernews'
+    };
+}
+
+export function parseHackerNewsSearchResponse(data: unknown, limit: number): SearchResult[] {
+    if (limit <= 0) {
+        return [];
+    }
+
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error('Hacker News Search returned an invalid response');
+    }
+
+    const hits = (data as { hits?: unknown }).hits;
+    if (!Array.isArray(hits)) {
+        throw new Error('Hacker News Search response is missing a hits array');
+    }
+
+    const results: SearchResult[] = [];
+    for (const hit of hits) {
+        const result = mapHackerNewsHit(hit);
+        if (!result) {
+            continue;
+        }
+        results.push(result);
+        if (results.length >= limit) {
+            break;
+        }
+    }
+
+    if (hits.length > 0 && results.length === 0) {
+        throw new Error('Hacker News Search returned no usable story hits');
+    }
+
+    return results;
+}
+
+export async function searchHackerNews(query: string, limit: number): Promise<SearchResult[]> {
+    const normalizedLimit = Math.floor(limit);
+    if (!Number.isFinite(normalizedLimit) || normalizedLimit <= 0) {
+        return [];
+    }
+
+    const hitsPerPage = Math.min(normalizedLimit, HACKER_NEWS_MAX_RESULTS);
+    const response = await hackerNewsHttpGet(HACKER_NEWS_SEARCH_URL, buildAxiosRequestOptions({
+        trustedStaticHost: true,
+        headers: {
+            Accept: 'application/json',
+            'User-Agent': 'open-websearch'
+        },
+        params: {
+            query,
+            tags: 'story',
+            hitsPerPage,
+            attributesToRetrieve: 'objectID,title,url,author,points,num_comments,created_at,story_text'
+        },
+        timeout: 15000,
+        maxContentLength: 2 * 1024 * 1024
+    }));
+
+    return parseHackerNewsSearchResponse(response.data, hitsPerPage);
+}

--- a/src/engines/hackernews/index.ts
+++ b/src/engines/hackernews/index.ts
@@ -1,0 +1,5 @@
+export {
+    __setHackerNewsHttpGetForTests,
+    parseHackerNewsSearchResponse,
+    searchHackerNews
+} from './hackernews.js';

--- a/src/runtime/createRuntime.ts
+++ b/src/runtime/createRuntime.ts
@@ -9,6 +9,7 @@ import { searchBrave } from '../engines/brave/index.js';
 import { searchJuejin } from '../engines/juejin/index.js';
 import { searchStartpage } from '../engines/startpage/index.js';
 import { searchSogou } from '../engines/sogou/index.js';
+import { searchHackerNews } from '../engines/hackernews/index.js';
 import { fetchLinuxDoArticle } from '../engines/linuxdo/fetchLinuxDoArticle.js';
 import { fetchCsdnArticle } from '../engines/csdn/fetchCsdnArticle.js';
 import { fetchJuejinArticle } from '../engines/juejin/fetchJuejinArticle.js';
@@ -50,7 +51,8 @@ function createDefaultSearchExecutors(): SearchEngineExecutorMap {
         brave: searchBrave,
         juejin: searchJuejin,
         startpage: searchStartpage,
-        sogou: searchSogou
+        sogou: searchSogou,
+        hackernews: searchHackerNews
     };
 }
 

--- a/src/test/test-cli-search.ts
+++ b/src/test/test-cli-search.ts
@@ -132,6 +132,15 @@ function testParseSearchArgs(): void {
     );
     assertEqual(parsedSogouAlias.engines.join(','), 'sogou', 'parsed Sogou alias');
 
+    const parsedHackerNewsAlias = parseSearchArgs(
+        ['Open', 'WebSearch', '--engine', 'Hacker News'],
+        createStubRuntime({
+            defaultSearchEngine: 'hackernews',
+            allowedSearchEngines: ['hackernews']
+        })
+    );
+    assertEqual(parsedHackerNewsAlias.engines.join(','), 'hackernews', 'parsed Hacker News alias');
+
     console.log('✅ CLI parseSearchArgs');
 }
 

--- a/src/test/test-core-search.ts
+++ b/src/test/test-core-search.ts
@@ -46,6 +46,8 @@ function testNormalizeEngineName(): void {
     assertEqual(normalizeEngineName('StartPage'), 'startpage', 'normalizes StartPage');
     assertEqual(normalizeEngineName('sou-gou'), 'sogou', 'normalizes sou-gou alias');
     assertEqual(normalizeEngineName('搜狗'), 'sogou', 'normalizes Chinese Sogou alias');
+    assertEqual(normalizeEngineName('Hacker News'), 'hackernews', 'normalizes Hacker News alias');
+    assertEqual(normalizeEngineName('hn'), 'hackernews', 'normalizes HN alias');
     assertEqualArray([...SUPPORTED_SEARCH_ENGINES], [
         'baidu',
         'bing',
@@ -56,7 +58,8 @@ function testNormalizeEngineName(): void {
         'brave',
         'juejin',
         'startpage',
-        'sogou'
+        'sogou',
+        'hackernews'
     ], 'supported engines list');
     console.log('✅ normalizeEngineName and supported engines');
 }

--- a/src/test/test-engine-normalization.ts
+++ b/src/test/test-engine-normalization.ts
@@ -11,7 +11,8 @@ const SUPPORTED_ENGINES = [
     'brave',
     'juejin',
     'startpage',
-    'sogou'
+    'sogou',
+    'hackernews'
 ] as const;
 
 const engineSchema = z.array(
@@ -41,7 +42,10 @@ const successCases: SuccessCase[] = [
     { input: ['StartPage'], expected: ['startpage'] },
     { input: ['SouGou'], expected: ['sogou'] },
     { input: ['sou-gou'], expected: ['sogou'] },
-    { input: ['搜狗'], expected: ['sogou'] }
+    { input: ['搜狗'], expected: ['sogou'] },
+    { input: ['Hacker News'], expected: ['hackernews'] },
+    { input: ['hacker-news'], expected: ['hackernews'] },
+    { input: ['hn'], expected: ['hackernews'] }
 ];
 
 const failureCases: FailureCase[] = [

--- a/src/test/test-hackernews.ts
+++ b/src/test/test-hackernews.ts
@@ -1,0 +1,256 @@
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import {
+    __setHackerNewsHttpGetForTests,
+    parseHackerNewsSearchResponse,
+    searchHackerNews
+} from '../engines/hackernews/index.js';
+import { createOpenWebSearchRuntime } from '../runtime/createRuntime.js';
+
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+    if (actual !== expected) {
+        throw new Error(`${label}: expected ${String(expected)}, got ${String(actual)}`);
+    }
+}
+
+function response(data: unknown): AxiosResponse {
+    return {
+        data,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: { headers: {} } as AxiosResponse['config']
+    };
+}
+
+async function testSearchRequestAndMapping(): Promise<void> {
+    let requestedUrl = '';
+    let requestedOptions: AxiosRequestConfig | undefined;
+    __setHackerNewsHttpGetForTests(async (url, options) => {
+        requestedUrl = url;
+        requestedOptions = options;
+        return response({
+            hits: [
+                {
+                    objectID: '42237424',
+                    title: 'Model Context Protocol',
+                    url: 'https://www.anthropic.com/news/model-context-protocol',
+                    author: 'benocodes',
+                    points: 872,
+                    num_comments: 258,
+                    created_at: '2024-11-25T16:14:22Z'
+                },
+                {
+                    objectID: '12345',
+                    title: 'Ask HN: A self post',
+                    url: null,
+                    author: 'alice',
+                    points: 1,
+                    num_comments: 1,
+                    story_text: '<p>How do you use <strong>MCP</strong> safely?</p><p>Hello<br>world</p><script>ignore()</script><style>.hidden{}</style>'
+                }
+            ]
+        });
+    });
+
+    const results = await searchHackerNews('Model Context Protocol & agents 中文', 2);
+
+    assertEqual(requestedUrl, 'https://hn.algolia.com/api/v1/search', 'fixed HN Search endpoint');
+    assertEqual(requestedOptions?.params?.query, 'Model Context Protocol & agents 中文', 'query parameter');
+    assertEqual(requestedOptions?.params?.tags, 'story', 'story-only tag');
+    assertEqual(requestedOptions?.params?.hitsPerPage, 2, 'result limit parameter');
+    assertEqual(
+        requestedOptions?.params?.attributesToRetrieve,
+        'objectID,title,url,author,points,num_comments,created_at,story_text',
+        'minimal response attributes'
+    );
+    assertEqual(requestedOptions?.timeout, 15000, 'request timeout');
+    assertEqual(requestedOptions?.maxContentLength, 2 * 1024 * 1024, 'response size limit');
+    assertEqual(requestedOptions?.maxRedirects, 0, 'fixed endpoint must not follow redirects');
+    assertEqual(requestedOptions?.proxy, false, 'request should use shared proxy handling');
+    assertEqual(results.length, 2, 'mapped result count');
+    assertEqual(results[0].title, 'Model Context Protocol', 'external story title');
+    assertEqual(results[0].url, 'https://www.anthropic.com/news/model-context-protocol', 'external story URL');
+    assertEqual(results[0].source, 'www.anthropic.com', 'external story source');
+    assertEqual(results[0].engine, 'hackernews', 'engine name');
+    assertEqual(results[0].description, 'By benocodes | 872 points | 258 comments | 2024-11-25', 'story metadata');
+    assertEqual(results[1].url, 'https://news.ycombinator.com/item?id=12345', 'self-post discussion fallback');
+    assertEqual(results[1].source, 'news.ycombinator.com', 'self-post source');
+    assertEqual(
+        results[1].description,
+        'How do you use MCP safely? Hello world | By alice | 1 point | 1 comment',
+        'self-post summary and singular metadata'
+    );
+
+    console.log('✓ Hacker News request and result mapping');
+}
+
+function testFallbacksAndMalformedHits(): void {
+    const results = parseHackerNewsSearchResponse({
+        hits: [
+            null,
+            'invalid',
+            { objectID: '199', title: '   ' },
+            {
+                objectID: '200',
+                title: 'First submission',
+                url: 'https://example.com/story'
+            },
+            {
+                objectID: '201',
+                title: 'Unsafe credential URL',
+                url: 'https://user:secret@example.com/private'
+            },
+            {
+                objectID: '202',
+                title: 'Unsupported scheme',
+                url: 'javascript:alert(1)'
+            },
+            {
+                objectID: '203',
+                title: 'Private literal URL',
+                url: 'http://127.0.0.1/private'
+            },
+            {
+                objectID: '204',
+                title: 'Localhost URL',
+                url: 'http://localhost/private'
+            },
+            {
+                objectID: '205',
+                title: 'IPv6 loopback URL',
+                url: 'http://[::1]/private'
+            },
+            {
+                objectID: '206',
+                title: 'Trailing-dot localhost URL',
+                url: 'http://foo.localhost./private'
+            },
+            {
+                objectID: '207',
+                title: 'Second discussion for same URL',
+                url: 'https://example.com/story'
+            },
+            {
+                objectID: 'not-an-id',
+                title: 'No usable URL',
+                url: 'file:///tmp/private'
+            }
+        ]
+    }, 10);
+
+    assertEqual(results.length, 8, 'skips malformed hits without dropping later valid stories');
+    assertEqual(results[0].title, 'First submission', 'valid hit after malformed entries');
+    assertEqual(results[0].url, 'https://example.com/story', 'external story URL');
+    assertEqual(results[1].url, 'https://news.ycombinator.com/item?id=201', 'credential URL fallback');
+    assertEqual(results[2].url, 'https://news.ycombinator.com/item?id=202', 'unsupported scheme fallback');
+    assertEqual(results[3].url, 'https://news.ycombinator.com/item?id=203', 'private literal URL fallback');
+    assertEqual(results[4].url, 'https://news.ycombinator.com/item?id=204', 'localhost URL fallback');
+    assertEqual(results[5].url, 'https://news.ycombinator.com/item?id=205', 'IPv6 loopback URL fallback');
+    assertEqual(results[6].url, 'https://news.ycombinator.com/item?id=206', 'trailing-dot localhost URL fallback');
+    assertEqual(results[7].title, 'Second discussion for same URL', 'preserves distinct HN stories for the same external URL');
+
+    console.log('✓ Hacker News fallbacks and malformed hits');
+}
+
+function testInvalidResponses(): void {
+    for (const value of [null, [], 'invalid', {}, { hits: {} }]) {
+        let threw = false;
+        try {
+            parseHackerNewsSearchResponse(value, 10);
+        } catch (error) {
+            threw = error instanceof Error && error.message.includes('Hacker News Search');
+        }
+        assert(threw, `invalid response should throw: ${JSON.stringify(value)}`);
+    }
+
+    for (const value of [
+        { hits: [null, 'invalid'] },
+        { hits: [{ objectID: 'not-an-id', title: 'No usable URL' }] }
+    ]) {
+        let threw = false;
+        try {
+            parseHackerNewsSearchResponse(value, 10);
+        } catch (error) {
+            threw = error instanceof Error && error.message.includes('no usable story hits');
+        }
+        assert(threw, `non-empty unusable hits should throw: ${JSON.stringify(value)}`);
+    }
+
+    console.log('✓ Hacker News invalid response handling');
+}
+
+async function testLimitAndErrorBehavior(): Promise<void> {
+    let calls = 0;
+    let seenLimit = 0;
+    __setHackerNewsHttpGetForTests(async (_url, options) => {
+        calls += 1;
+        seenLimit = Number(options.params?.hitsPerPage);
+        return response({ hits: [] });
+    });
+
+    assertEqual((await searchHackerNews('zero', 0)).length, 0, 'zero-limit result');
+    assertEqual(calls, 0, 'zero limit should not make a request');
+    await searchHackerNews('bounded', 75);
+    assertEqual(seenLimit, 50, 'direct calls clamp API page size');
+
+    const upstreamError = new Error('rate limited');
+    __setHackerNewsHttpGetForTests(async () => {
+        throw upstreamError;
+    });
+    let receivedError: unknown;
+    try {
+        await searchHackerNews('failure', 1);
+    } catch (error) {
+        receivedError = error;
+    }
+    assert(receivedError === upstreamError, 'upstream errors should propagate to the shared partial-failure handler');
+
+    console.log('✓ Hacker News limits and error propagation');
+}
+
+async function testDefaultRuntimeRegistration(): Promise<void> {
+    __setHackerNewsHttpGetForTests(async () => response({
+        hits: [{ objectID: '300', title: 'Registered engine' }]
+    }));
+
+    const runtime = createOpenWebSearchRuntime();
+    const result = await runtime.services.search.execute({
+        query: 'runtime registration',
+        engines: ['hackernews'],
+        limit: 1
+    });
+
+    assertEqual(result.partialFailures.length, 0, 'default runtime partial failures');
+    assertEqual(result.totalResults, 1, 'default runtime result count');
+    assertEqual(result.results[0].engine, 'hackernews', 'default runtime engine registration');
+
+    console.log('✓ Hacker News default runtime registration');
+}
+
+async function main(): Promise<void> {
+    try {
+        await testSearchRequestAndMapping();
+        testFallbacksAndMalformedHits();
+        testInvalidResponses();
+        await testLimitAndErrorBehavior();
+        await testDefaultRuntimeRegistration();
+        console.log('\nHacker News tests passed.');
+    } finally {
+        __setHackerNewsHttpGetForTests();
+    }
+}
+
+main()
+    .then(() => {
+        process.exit(0);
+    })
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/src/test/test-mcp-adapter.ts
+++ b/src/test/test-mcp-adapter.ts
@@ -195,6 +195,32 @@ async function testSetupToolsUsesRuntimeConfigDefaults(): Promise<void> {
     console.log('✅ setupTools uses runtime.config defaults');
 }
 
+function testSearchSchemaSupportsHackerNews(): void {
+    const server = new McpServer({ name: 'test', version: '1.0.0' });
+    setupTools(server, createOpenWebSearchRuntime({ config: createTestConfig() }));
+
+    const tools = (server as unknown as {
+        _registeredTools: Record<string, {
+            description: string;
+            inputSchema: { safeParse: (input: unknown) => { success: boolean } };
+        }>;
+    })._registeredTools;
+    const accepted = tools.search.inputSchema.safeParse({
+        query: 'Model Context Protocol',
+        engines: ['Hacker News']
+    });
+    const rejected = tools.search.inputSchema.safeParse({
+        query: 'Model Context Protocol',
+        engines: ['not-a-real-engine']
+    });
+
+    assert(accepted.success, 'MCP search schema should accept the Hacker News alias');
+    assert(!rejected.success, 'MCP search schema should still reject unsupported engines');
+    assert(tools.search.description.includes('Hacker News'), 'MCP search description should mention Hacker News');
+
+    console.log('✅ MCP search schema supports Hacker News');
+}
+
 async function testSearchToolPassesSearchModeOverride(): Promise<void> {
     const seenCalls: Array<{ searchMode?: string }> = [];
     // 只有 SEARCH_MODE=auto 且 Playwright 可用时，searchMode 参数才会注册并转发；因此这里使用 auto + 远端端点配置。
@@ -424,8 +450,8 @@ function testConfigDrivenEngineSelectionAndMode(): void {
         `,
         {
             MODE: 'stdio',
-            DEFAULT_SEARCH_ENGINE: 'duckduckgo',
-            ALLOWED_SEARCH_ENGINES: 'duckduckgo,bing,exa',
+            DEFAULT_SEARCH_ENGINE: 'hackernews',
+            ALLOWED_SEARCH_ENGINES: 'hackernews,bing,exa',
             SEARCH_MODE: 'auto',
             USE_PROXY: 'true',
             PROXY_URL: 'http://127.0.0.1:7890',
@@ -445,8 +471,8 @@ function testConfigDrivenEngineSelectionAndMode(): void {
         enableHttpServer: boolean;
     };
 
-    assertEqual(configPayload.defaultSearchEngine, 'duckduckgo', 'configured default search engine');
-    assertEqual(configPayload.allowedSearchEngines.join(','), 'duckduckgo,bing,exa', 'configured allowed search engines');
+    assertEqual(configPayload.defaultSearchEngine, 'hackernews', 'configured default search engine');
+    assertEqual(configPayload.allowedSearchEngines.join(','), 'hackernews,bing,exa', 'configured allowed search engines');
     assertEqual(configPayload.searchMode, 'auto', 'configured search mode');
     assertEqual(configPayload.useProxy, true, 'configured useProxy');
     assertEqual(configPayload.proxyUrl, 'http://127.0.0.1:7890', 'configured proxyUrl');
@@ -489,8 +515,8 @@ function testConfigDrivenEngineSelectionAndMode(): void {
             }, null, 2));
         `,
         {
-            ALLOWED_SEARCH_ENGINES: 'duckduckgo,bing',
-            DEFAULT_SEARCH_ENGINE: 'duckduckgo',
+            ALLOWED_SEARCH_ENGINES: 'hackernews,bing',
+            DEFAULT_SEARCH_ENGINE: 'hackernews',
             // 显式清零 Playwright 参数，确保“参数不足退回请求模式”断言不受宿主环境污染影响。
             PLAYWRIGHT_MODULE_PATH: '',
             PLAYWRIGHT_PACKAGE: '',
@@ -505,7 +531,7 @@ function testConfigDrivenEngineSelectionAndMode(): void {
     };
     assert(descriptionPayload.names.includes('search'), 'default search tool should still be registered');
     assert(
-        descriptionPayload.searchDescription.includes('Duckduckgo') &&
+        descriptionPayload.searchDescription.includes('Hacker News') &&
         descriptionPayload.searchDescription.includes('Bing'),
         'search description should reflect allowed engines'
     );
@@ -678,6 +704,7 @@ function testConfigDrivenEngineSelectionAndMode(): void {
 async function main(): Promise<void> {
     await testSearchToolReturnsCompatiblePayload();
     await testSetupToolsUsesRuntimeConfigDefaults();
+    testSearchSchemaSupportsHackerNews();
     await testSearchToolPassesSearchModeOverride();
     await testSearchToolAutoModeUsesRuntimeDefault();
     await testFetchWebToolPassesReadabilityFlags();

--- a/src/test/test-url-safety.ts
+++ b/src/test/test-url-safety.ts
@@ -14,6 +14,8 @@ function assertEqual(actual: boolean, expected: boolean, message: string): void 
 function runHostCases(): void {
     const hostCases: Case[] = [
         { value: 'localhost', expected: true },
+        { value: 'localhost.', expected: true },
+        { value: 'foo.localhost.', expected: true },
         { value: '127.0.0.1', expected: true },
         { value: '10.0.0.5', expected: true },
         { value: '172.20.1.8', expected: true },
@@ -38,6 +40,7 @@ function runUrlCases(): void {
         { value: 'http://8.8.8.8/resource', expected: true },
         { value: 'ftp://example.com/file', expected: false },
         { value: 'http://localhost:3000/secret', expected: false },
+        { value: 'http://foo.localhost./secret', expected: false },
         { value: 'http://127.0.0.1/admin', expected: false },
         { value: 'http://169.254.169.254/latest/meta-data', expected: false }
     ];

--- a/src/tools/setupTools.ts
+++ b/src/tools/setupTools.ts
@@ -55,7 +55,7 @@ export const setupTools = (server: McpServer, runtime: OpenWebSearchRuntime): vo
             ? ' searchMode meanings: request performs plain HTTP scraping, playwright drives a real browser through Playwright, and auto or omitting searchMode lets the server decide (request first, falling back to Playwright when it is blocked). Start with the default auto (or omit searchMode). Only retry the same query with searchMode=playwright when the request-based results fail, come back empty, or are clearly blocked or low-quality, for example anti-bot or verification pages.'
             : '';
         if (runtime.config.allowedSearchEngines.length === 0) {
-            return `Search the web using multiple engines (e.g., Baidu, Bing, DuckDuckGo, CSDN, Exa, Brave, Juejin(掘金), Startpage, Sogou(搜狗)) with no API key required.${searchModeDescription}`;
+            return `Search the web using multiple engines (e.g., Baidu, Bing, DuckDuckGo, CSDN, Exa, Brave, Juejin(掘金), Startpage, Sogou(搜狗), Hacker News) with no API key required.${searchModeDescription}`;
         } else {
             const enginesText = runtime.config.allowedSearchEngines.map(e => {
                 switch (e) {
@@ -65,6 +65,8 @@ export const setupTools = (server: McpServer, runtime: OpenWebSearchRuntime): vo
                         return 'Startpage';
                     case 'sogou':
                         return 'Sogou(搜狗)';
+                    case 'hackernews':
+                        return 'Hacker News';
                     default:
                         return e.charAt(0).toUpperCase() + e.slice(1);
                 }

--- a/src/utils/urlSafety.ts
+++ b/src/utils/urlSafety.ts
@@ -6,7 +6,10 @@ import { config } from '../config.js';
 // URL.hostname preserves the brackets for IPv6 literals (`[::1]`), which
 // break isIP and dns.lookup. Strip them once here.
 function stripIpv6Brackets(host: string): string {
-    return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+    const withoutRootDots = host.replace(/\.+$/, '');
+    return withoutRootDots.startsWith('[') && withoutRootDots.endsWith(']')
+        ? withoutRootDots.slice(1, -1)
+        : withoutRootDots;
 }
 
 type LookupResult = Array<{ address: string }>;


### PR DESCRIPTION
## Summary

- add a keyless `hackernews` search engine backed by the HN Search API
- query relevance-ranked Hacker News stories and map them to the shared search result shape
- return submitted URLs when safe, otherwise fall back to the canonical Hacker News discussion URL
- include cleaned self-post text plus author, points, comment count, and date metadata
- register `hackernews` across runtime configuration, MCP, CLI, daemon-backed search, documentation, and engine aliases (`Hacker News`, `hacker-news`, `hn`)

Closes #80.

## Reliability and safety

- use a fixed HTTPS API endpoint with redirects disabled, a 15-second timeout, and a 2 MiB response cap
- request only the fields needed for story results
- treat malformed non-empty API payloads as engine failures so the shared `partialFailures` contract exposes upstream schema breakage
- reject credential-bearing, non-HTTP, literal private, loopback, and local result URLs and use the HN discussion URL instead
- preserve distinct Hacker News submissions that point to the same external page
- normalize self-post HTML while preserving paragraph/list/line-break boundaries and dropping script/style content

## Verification

- `npm run build`
- `npm run test:hackernews`
- `npm run test:core-search`
- `npm run test:engine-normalization`
- `npm run test:mcp-adapter`
- `npm run test:cli-search`
- `npm run test:url-safety`
- `npm test`: 31 deterministic tests passed; 2 existing live network tests were excused by the repository runner because this machine resolves their targets through a fake-IP DNS range; the runner also skips the existing cross-restart browser concurrency test by design
- real CLI smoke: search `Ask HN MCP` with `--engine hackernews --limit 3 --json` returned 3 Hacker News stories, including self-post text and canonical discussion URLs
- `git diff --cached --check`

OpenAI Codex assisted with implementation, test design, and review. I reviewed, understood, and verified the submitted changes.
