### PR TITLE
docs: 修复 Star History 图表

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -858,6 +858,6 @@ use_mcp_tool({
 ## Star History
 如果项目对你有帮助，请考虑给个⭐ Star！
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Aas-ee/open-webSearch&type=Date)](https://www.star-history.com/#Aas-ee/open-webSearch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Aas-ee/open-webSearch&type=Date)](https://star-history.dera.page/#Aas-ee/open-webSearch&Date)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -763,6 +763,6 @@ The repository includes a GitHub Actions workflow (`.github/workflows/docker.yml
 ## Star History
 If you find this project helpful, please consider giving it a ⭐ Star!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Aas-ee/open-webSearch&type=Date)](https://www.star-history.com/#Aas-ee/open-webSearch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Aas-ee/open-webSearch&type=Date)](https://star-history.dera.page/#Aas-ee/open-webSearch&Date)
 
 </div>


### PR DESCRIPTION
当前 README 底部的 Star History 图表已无法正常加载。受 GitHub stargazer 接口限制影响，原有图表渲染失效，本项目需要一个可正常展示的数据源。本 PR 将其切换到新的服务地址并保留原有参数，图标将可重新正常显示。