### PR TITLE
fix(baidu): surface anti-bot captcha instead of raw 302 failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:mcp-adapter": "tsc && node build/test/test-mcp-adapter.js",
     "test:runtime": "tsc && node build/test/test-runtime.js",
     "test:sogou": "tsc && node build/test/test-sogou.js",
+    "test:baidu": "tsc && node build/test/test-baidu.js",
     "test:startpage": "tsc && node build/test/test-startpage.js",
     "test:http-request-options": "tsc && node build/test/test-http-request-options.js",
     "test:url-safety": "tsc && node build/test/test-url-safety.js",

--- a/src/engines/baidu/baidu.ts
+++ b/src/engines/baidu/baidu.ts
@@ -1,74 +1,137 @@
 import axios from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as cheerio from 'cheerio';
 import { SearchResult } from '../../types.js';
 import { buildAxiosRequestOptions } from '../../utils/httpRequest.js';
 
-export async function searchBaidu(query: string, limit: number): Promise<SearchResult[]> {
-    let allResults: SearchResult[] = [];
-    let pn = 0;
+const BAIDU_SEARCH_URL = 'https://www.baidu.com/s';
+const BAIDU_PAGE_SIZE = 10;
 
-    while (allResults.length < limit) {
-        const response = await axios.get('https://www.baidu.com/s', buildAxiosRequestOptions({
-            trustedStaticHost: true,
-            params: {
-                wd: query,
-                pn: pn.toString(),
-                ie: "utf-8",
-                mod: "1",
-                isbd: "1",
-                isid: "f7ba1776007bcf9e",
-                oq: query,
-                tn: "88093251_62_hao_pg",
-                usm: "1",
-                fenlei: "256",
-                rsv_idx: "1",
-                rsv_pq: "f7ba1776007bcf9e",
-                rsv_t: "8179fxGiNMUh/0dXHrLsJXPlKYbkj9S5QH6rOLHY6pG6OGQ81YqzRTIGjjeMwEfiYQTSiTQIhCJj",
-                bs: query,
-                rsv_sid: undefined,
-                _ss: "1",
-                f4s: "1",
-                csor: "5",
-                _cr1: "30385",
-            },
-            headers: {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
-            }
-        }));
+// hao123 个人页的稳定客户端标识：百度对纯请求会 302 到 wappass 验证码，
+// 带上该 tn 才返回正常搜索结果页。它是长期固定的客户端 id，不是会过期的会话 token。
+const BAIDU_TN = '88093251_62_hao_pg';
 
-        const $ = cheerio.load(response.data);
-        const results: SearchResult[] = [];
+const COMMON_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+};
 
-        $('#content_left').children().each((i, element) => {
-            const titleElement = $(element).find('h3');
-            const linkElement = $(element).find('a');
-            const snippetElement = $(element).find('.cos-row').first();
+type BaiduHttpGet = (url: string, options: AxiosRequestConfig) => Promise<AxiosResponse>;
 
-            if (titleElement.length && linkElement.length) {
-                const url = linkElement.attr('href');
-                if (url && url.startsWith('http')) {
-                    const snippetElementBaidu = $(element).find('.c-font-normal.c-color-text').first();
-                    const sourceElement = $(element).find('.cosc-source');
-                    results.push({
-                        title: titleElement.text(),
-                        url: url,
-                        description: snippetElementBaidu.attr('aria-label') || snippetElement.text().trim() || '',
-                        source: sourceElement.text().trim() || '',
-                        engine: 'baidu'
-                    });
-                }
-            }
-        });
+let baiduHttpGet: BaiduHttpGet = (url, options) => axios.get(url, options);
 
-        allResults = allResults.concat(results);
+export function __setBaiduHttpGetForTests(impl?: BaiduHttpGet): void {
+    baiduHttpGet = impl ?? ((url, options) => axios.get(url, options));
+}
 
-        if (results.length === 0) {
-            console.error('⚠️ No more results, ending early....');
-            break;
-        }
+function normalizeText(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
 
-        pn += 10;
+/**
+ * 百度限流时会把请求 302 到 `wappass.baidu.com/static/captcha/...`。Location 命中这些
+ * 关键词即视为安全验证拦截，而不是普通跳转。
+ */
+function isBaiduChallengeRedirect(location: string): boolean {
+    return /wappass|captcha|antispider|verify/i.test(location);
+}
+
+function isBaiduChallengePage(html: string): boolean {
+    const normalized = html.toLowerCase();
+    const $ = cheerio.load(html);
+    const title = $('title').first().text().trim();
+
+    return normalized.includes('wappass')
+        || normalized.includes('百度安全验证')
+        || normalized.includes('请输入验证码')
+        || normalized.includes('antispider')
+        || title.includes('验证');
+}
+
+export function parseBaiduSearchResults(html: string): SearchResult[] {
+    if (isBaiduChallengePage(html)) {
+        throw new Error('Baidu returned a security verification or anti-bot page');
     }
 
-    return allResults.slice(0, limit); // 截取最多 limit 个
+    const $ = cheerio.load(html);
+    const results: SearchResult[] = [];
+
+    $('#content_left').children().each((_, element) => {
+        const card = $(element);
+        const titleElement = card.find('h3').first();
+        const linkElement = card.find('a').first();
+        const snippetElement = card.find('.cos-row').first();
+        const snippetElementBaidu = card.find('.c-font-normal.c-color-text').first();
+        const sourceElement = card.find('.cosc-source').first();
+
+        if (!titleElement.length || !linkElement.length) {
+            return;
+        }
+
+        const url = linkElement.attr('href');
+        if (!url || !url.startsWith('http')) {
+            return;
+        }
+
+        results.push({
+            title: normalizeText(titleElement.text()),
+            url,
+            description: snippetElementBaidu.attr('aria-label') || normalizeText(snippetElement.text()),
+            source: normalizeText(sourceElement.text()),
+            engine: 'baidu',
+        });
+    });
+
+    return results;
+}
+
+async function searchBaiduPage(query: string, page: number): Promise<SearchResult[]> {
+    const url = new URL(BAIDU_SEARCH_URL);
+    url.searchParams.set('wd', query);
+    url.searchParams.set('tn', BAIDU_TN);
+    url.searchParams.set('ie', 'utf-8');
+    url.searchParams.set('pn', String(page * BAIDU_PAGE_SIZE));
+
+    // trustedStaticHost 会强制 maxRedirects=0：302 不被静默跟随，而是在下面显式识别，
+    // 避免把 wappass 验证码跳转误当成正常结果页解析出 0 条。
+    const response = await baiduHttpGet(url.toString(), buildAxiosRequestOptions({
+        trustedStaticHost: true,
+        headers: COMMON_HEADERS,
+        timeout: 20000,
+        validateStatus: (status) => status >= 200 && status < 400,
+    }));
+
+    if (response.status >= 300 && response.status < 400) {
+        const location = String(response.headers?.location || '');
+        if (isBaiduChallengeRedirect(location)) {
+            throw new Error('Baidu redirected to a security verification page');
+        }
+        throw new Error(`Baidu returned an unexpected redirect: ${location || response.status}`);
+    }
+
+    return parseBaiduSearchResults(String(response.data || ''));
+}
+
+export async function searchBaidu(query: string, limit: number): Promise<SearchResult[]> {
+    const allResults: SearchResult[] = [];
+    const seenUrls = new Set<string>();
+    const maxPage = Math.max(1, Math.ceil(limit / BAIDU_PAGE_SIZE));
+
+    for (let page = 0; page < maxPage && allResults.length < limit; page += 1) {
+        const pageResults = await searchBaiduPage(query, page);
+        for (const result of pageResults) {
+            if (seenUrls.has(result.url)) {
+                continue;
+            }
+            seenUrls.add(result.url);
+            allResults.push(result);
+        }
+
+        if (pageResults.length === 0) {
+            break;
+        }
+    }
+
+    return allResults.slice(0, limit);
 }

--- a/src/engines/baidu/index.ts
+++ b/src/engines/baidu/index.ts
@@ -1,1 +1,1 @@
-export { searchBaidu } from './baidu.js';
+export { __setBaiduHttpGetForTests, parseBaiduSearchResults, searchBaidu } from './baidu.js';

--- a/src/test/test-baidu.ts
+++ b/src/test/test-baidu.ts
@@ -1,38 +1,141 @@
-import { searchBaidu } from '../engines/baidu/index.js';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { __setBaiduHttpGetForTests, parseBaiduSearchResults, searchBaidu } from '../engines/baidu/index.js';
 
-async function testBaiduSearch() {
-  console.log('🔍 Starting Baidu search test...');
-
-  try {
-    const query = 'websearch mcp';
-    const maxResults = 25;
-
-    console.log(`📝 Search query: ${query}`);
-    console.log(`📊 Maximum results: ${maxResults}`);
-
-    const results = await searchBaidu(query, maxResults);
-
-    console.log(`🎉 Search completed, retrieved ${results.length} results:`);
-    results.forEach((result, index) => {
-      console.log(`\n${index + 1}. ${result.title}`);
-      console.log(`   🔗 ${result.url}`);
-      console.log(`   📄 ${result.description.substring(0, 100)}...`);
-      console.log(`   🌐 Source: ${result.source}`);
-    });
-
-    return results;
-  } catch (error) {
-    console.error('❌ Test failed:', error);
-    return [];
-  }
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) {
+        throw new Error(message);
+    }
 }
 
-// Run the test
-testBaiduSearch()
-  .then(() => {
-    process.exit(0);
-  })
-  .catch((error) => {
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+    if (actual !== expected) {
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+    }
+}
+
+function makeResponse(status: number, headers: Record<string, string | string[]>, data: string): AxiosResponse {
+    return {
+        status,
+        statusText: String(status),
+        headers,
+        data,
+        config: {} as AxiosResponse['config'],
+    };
+}
+
+function testParseBaiduResults(): void {
+    const html = `
+        <html>
+          <body>
+            <div id="content_left">
+              <div class="result c-container new-pmd">
+                <h3><a href="http://www.baidu.com/link?url=first">First Result</a></h3>
+                <div class="cos-row">First snippet.</div>
+                <div class="cosc-source">example.com</div>
+              </div>
+              <div class="result c-container new-pmd">
+                <h3><a href="http://www.baidu.com/link?url=second">Second Result</a></h3>
+                <div class="cos-row">Second snippet.</div>
+                <div class="cosc-source">docs.example.com</div>
+              </div>
+              <div class="result c-container new-pmd">
+                <h3>No link here</h3>
+              </div>
+              <div class="result c-container new-pmd">
+                <h3><a href="javascript:void(0)">Script link</a></h3>
+              </div>
+            </div>
+          </body>
+        </html>
+    `;
+
+    const results = parseBaiduSearchResults(html);
+
+    assertEqual(results.length, 2, 'parsed result count');
+    assertEqual(results[0].title, 'First Result', 'first title');
+    assertEqual(results[0].url, 'http://www.baidu.com/link?url=first', 'first url');
+    assertEqual(results[0].description, 'First snippet.', 'first description');
+    assertEqual(results[0].source, 'example.com', 'first source');
+    assertEqual(results[0].engine, 'baidu', 'first engine');
+    assertEqual(results[1].title, 'Second Result', 'second title');
+
+    console.log('✅ parse Baidu HTML results');
+}
+
+function testBaiduChallengePageDetection(): void {
+    let threw = false;
+    try {
+        parseBaiduSearchResults('<html><title>百度安全验证</title><body>请输入验证码</body></html>');
+    } catch (error) {
+        threw = error instanceof Error && error.message.includes('verification');
+    }
+
+    assert(threw, 'Baidu challenge page should throw a verification error');
+    console.log('✅ detect Baidu verification page');
+}
+
+async function testSearchBaiduDetectsCaptchaRedirect(): Promise<void> {
+    __setBaiduHttpGetForTests(async () => makeResponse(
+        302,
+        { location: 'https://wappass.baidu.com/static/captcha/tuxing_v2.html?ak=abc' },
+        '',
+    ));
+
+    try {
+        await searchBaidu('test', 10);
+        throw new Error('searchBaidu should throw on a captcha redirect');
+    } catch (error) {
+        assert(
+            error instanceof Error && error.message.includes('verification'),
+            'captcha redirect should surface a verification error',
+        );
+    } finally {
+        __setBaiduHttpGetForTests();
+    }
+
+    console.log('✅ Baidu search surfaces captcha redirect');
+}
+
+async function testSearchBaiduParsesResults(): Promise<void> {
+    const requestedUrls: string[] = [];
+    __setBaiduHttpGetForTests(async (url: string, _options: AxiosRequestConfig) => {
+        requestedUrls.push(url);
+        return makeResponse(
+            200,
+            {},
+            `
+              <div id="content_left">
+                <div class="result c-container new-pmd">
+                  <h3><a href="http://www.baidu.com/link?url=hello">Hello</a></h3>
+                  <div class="cos-row">Greeting snippet.</div>
+                </div>
+              </div>
+            `,
+        );
+    });
+
+    try {
+        const results = await searchBaidu('你好', 5);
+        assertEqual(results.length, 1, 'search result count');
+        assertEqual(results[0].title, 'Hello', 'search result title');
+        assert(requestedUrls.length === 1, 'Baidu search should make one request');
+        assert(requestedUrls[0].startsWith('https://www.baidu.com/s?'), 'request should use Baidu search endpoint');
+        assert(requestedUrls[0].includes('tn=88093251_62_hao_pg'), 'request should carry the stable hao123 tn');
+        console.log('✅ Baidu search parses results and keeps the stable tn');
+    } finally {
+        __setBaiduHttpGetForTests();
+    }
+}
+
+async function main(): Promise<void> {
+    testParseBaiduResults();
+    testBaiduChallengePageDetection();
+    await testSearchBaiduDetectsCaptchaRedirect();
+    await testSearchBaiduParsesResults();
+    console.log('\nBaidu tests passed.');
+}
+
+main().catch((error) => {
     console.error(error);
     process.exit(1);
-  });
+});


### PR DESCRIPTION
## 解决什么

#93：百度限流时会把 `/s` 请求 302 到 `wappass.baidu.com/static/captcha/...` 验证码页。此前引擎有两个问题：

1. 不带 `validateStatus`，而 `trustedStaticHost` 又强制 `maxRedirects=0`，所以遇到 302 直接抛原始 `Request failed with status code 302`，对用户毫无提示意义。
2. 即便拿到验证码页，解析器也只会静默解析出 0 条结果，用户分不清是「没有结果」还是「被反爬」。

## 怎么做的

- **302 → 清晰错误**：`validateStatus` 接受 3xx，检查 `Location` 命中 `wappass|captcha|antispider|verify` 时抛「Baidu redirected to a security verification page」，其它跳转抛「unexpected redirect」。
- **挑战页检测**：`parseBaiduSearchResults` 在解析前先检查 HTML 是否验证码页（wappass / 百度安全验证 / 请输入验证码 / antispider / 标题含「验证」），命中即抛「security verification or anti-bot page」。
- **精简参数**：删掉会过期的会话 token（`rsv_*` / `isid` / `oq` / `bs` / `mod` / `isbd` 等），只保留稳定的 `wd / tn / ie / pn`。`tn=88093251_62_hao_pg` 是长期固定的 hao123 客户端标识（非会话 token），实测仅 `wd+tn+ie+pn` 即可返回正常结果页。
- **可测试性**：抽取 `parseBaiduSearchResults` + 新增 `__setBaiduHttpGetForTests` hook（对齐 sogou 引擎的既有结构），`test-baidu` 从「依赖真实网络的 live 测试」改为确定性单测。
- **新增 `test:baidu` 脚本**。

## 验证

- `npx tsc` 通过
- `npm run test:baidu`：4 项单测全过（解析 / 挑战页检测 / 302 验证码重定向 / 保持稳定 tn）
- `npm test`：31 通过、4 个网络问题按既有规则赦免

## 边界

- 结果 URL 仍为百度的 `www.baidu.com/link?url=...` 跳转链接（原有行为，本次未改）。
- 百度反爬策略可能变化，`tn` 标识未来若失效需维护者再确认。

Refs #93